### PR TITLE
Clear search text shows up when the search query has multiple blankspaces

### DIFF
--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/BodyFragment.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/BodyFragment.kt
@@ -150,7 +150,7 @@ class BodyFragment : BaseFragment(R.layout.fragment_body) {
 
         setupWebView()
 
-        if(bodyUrl.searchQuery.isNotEmpty()){
+        if(bodyUrl.searchQuery.isNotEmpty() && !isOnlyWhitespace(bodyUrl.searchQuery)){
             bind.searchClearText.text = bodyUrl.searchQuery
             bind.searchClearContainer.visibility = View.VISIBLE
             bind.searchClearButton.setOnClickListener {


### PR DESCRIPTION
Checks if text is not empty and not all whitespaces