### PR TITLE
change case sensitive inputs

### DIFF
--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/adapters/FAGlobalSearchAdapter.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/adapters/FAGlobalSearchAdapter.kt
@@ -41,8 +41,8 @@ class FAGlobalSearchAdapter @Inject constructor(
         textInBody.subSequence(getSearchStartPosition(textInBody), textInBody.length).toString()
 
     private fun getSearchStartPosition(textInBody: String) =
-        if (textInBody.lowercase().indexOf(searchQuery) == -1) 0
-        else textInBody.lowercase().indexOf(searchQuery)
+        if (textInBody.indexOf(searchQuery) == -1) 0
+        else textInBody.indexOf(searchQuery)
 
     inner class ViewHolder(private val fragmentGlobalSearchItemBinding: FragmentGlobalSearchItemBinding) :
         RecyclerView.ViewHolder(fragmentGlobalSearchItemBinding.root) {

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/utils/ExtensionMethods.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/utils/ExtensionMethods.kt
@@ -51,7 +51,7 @@ fun EditText.setOnTextWatcher(
             count: Int
         ) {
             charSequence?.let {
-                if (it.isNotBlank()) onTextChangedListener(it.toString().lowercase().trim())
+                if (it.isNotBlank()) onTextChangedListener(it.toString().trim())
             }
 
         }


### PR DESCRIPTION
the case sensitivity was built into the input code ,but when its removed the code is built to to search sensitively meaning the code has to be modified in terms of how it searches

 override fun onTextChanged(
            charSequence: CharSequence?,
            start: Int,
            before: Int,
            count: Int
        ) {
            charSequence?.let {
                if (it.isNotBlank()) onTextChangedListener(it.toString().trim())
            }

        }