### PR TITLE
remove highlighting for title

### DIFF
--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/GlobalSearchFragment.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/GlobalSearchFragment.kt
@@ -86,7 +86,7 @@ class GlobalSearchFragment : BaseFragment(R.layout.fragment_global_search) {
                     )
                 }
 
-         
+
                 faGlobalSearchAdapter.submitList(highlightedWord)
                 highlightedWord.size.noItemFound(bind.visibleViewGroup, bind.noItemFound)
                 "${highlightedWord.size} result${if (highlightedWord.size == 1) "" else "s"}".also {


### PR DESCRIPTION
No highlighting for title in cards happening for body and subtitle 
**changes**
app\src\main\java\org\apphatchery\gatbreferenceguide\ui\fragments\GlobalSearchFragment.kt

![image](https://github.com/AppHatchery/GATBReferenceGuide-Android/assets/17104217/468420e7-17f5-4d79-86cf-f49d42b9aaa4)

![image](https://github.com/AppHatchery/GATBReferenceGuide-Android/assets/17104217/9e1a9f08-3e97-4a30-a3f4-d0ee23b45282)



