### PR TITLE
duplication fix

### DIFF
--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/Database.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/Database.kt
@@ -2,6 +2,9 @@ package org.apphatchery.gatbreferenceguide.db
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.apphatchery.gatbreferenceguide.db.dao.*
 import org.apphatchery.gatbreferenceguide.db.entities.*
 
@@ -28,4 +31,17 @@ abstract class Database : RoomDatabase() {
     abstract fun globalSearchDao(): GlobalSearchDao
     abstract fun recentDao(): RecentDao
     abstract fun contactDao(): ContactDao
+
+  @OptIn(DelicateCoroutinesApi::class)
+  fun purgeData(){
+      GlobalScope.launch {
+          chapterDao().deleteAll()
+          chartDao().deleteAll()
+          subChapterDao().deleteAll()
+          htmlInfoDao().deleteAll()
+          globalSearchDao().deleteAll()
+      }
+
+
+    }
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/ChapterDao.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/ChapterDao.kt
@@ -20,4 +20,7 @@ interface ChapterDao {
 
     @Query("SELECT  * FROM  ChapterEntity WHERE chapterId =:id")
     fun getChapterById(id: Int): Flow<ChapterEntity>
+
+    @Query("DELETE FROM ChapterEntity")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/ChartDao.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/ChartDao.kt
@@ -27,4 +27,7 @@ interface ChartDao {
     @Query("SELECT  * FROM  ChartEntity  JOIN SubChapterEntity USING(subChapterTitle) WHERE ChartEntity.id=:id")
     fun getChartAndSubChapterById(id: String): Flow<ChartAndSubChapter>
 
+    @Query("DELETE FROM ChartEntity")
+    suspend fun deleteAll()
+
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/GlobalSearchDao.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/GlobalSearchDao.kt
@@ -20,4 +20,7 @@ interface GlobalSearchDao {
     )
     fun getGlobalSearchEntity(keyword: String =""): Flow<List<GlobalSearchEntity>>
 
+    @Query("DELETE FROM GlobalSearchEntity")
+    suspend fun deleteAll()
+
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/HtmlInfoDao.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/HtmlInfoDao.kt
@@ -19,4 +19,7 @@ interface HtmlInfoDao {
     @Query("SELECT  * FROM  HtmlInfoEntity")
    suspend fun getHtmlInfoEntitySuspended(): List<HtmlInfoEntity>
 
+    @Query("DELETE FROM HtmlInfoEntity")
+    suspend fun deleteAll()
+
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/SubChapterDao.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/SubChapterDao.kt
@@ -7,7 +7,8 @@ import org.apphatchery.gatbreferenceguide.db.entities.SubChapterEntity
 
 @Dao
 interface SubChapterDao {
-
+    @Query("DELETE FROM SubChapterEntity")
+    suspend fun deleteAll()
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(data: List<SubChapterEntity>)
 

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/repositories/Repository.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/repositories/Repository.kt
@@ -17,6 +17,10 @@ class Repository @Inject constructor(
     private val subChapterDao = db.subChapterDao()
     private val chartDao = db.chartDao()
 
+    fun purgeData(){
+        db.purgeData()
+    }
+
 
     fun dumpChapterInfo(data: List<ChapterEntity>) = networkBoundResource(
         query = { chapterDao.getChapterEntity() },

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/MainFragment.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/MainFragment.kt
@@ -148,9 +148,14 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
         fragmentMainBinding = FragmentMainBinding.bind(view)
         userPrefs.getBuildVersion.asLiveData().observe(viewLifecycleOwner) {
-            if (it != BUILD_VERSION) firstLaunch() else {
+            if (it != BUILD_VERSION)
+            {
+                firstLaunch()
+            }
+            else {
                 init()
             }
         }
@@ -301,6 +306,7 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
 
     private fun firstLaunch() {
         requireActivity().apply {
+            viewModel.purgeData()
             getBottomNavigationView()?.toggleVisibility(false)
             createHtmlAndAssetsDirectoryIfNotExists()
             prepHtmlPlusAssets()

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/viewmodels/FAMainViewModel.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/viewmodels/FAMainViewModel.kt
@@ -30,6 +30,10 @@ class FAMainViewModel @Inject constructor(
     private val taskFlowChannel = Channel<Callback>()
     val taskFlowEvent = taskFlowChannel.receiveAsFlow()
 
+    fun purgeData(){
+        repo.purgeData()
+    }
+
 
     fun dumpChapterData(data: List<ChapterEntity>) = repo.dumpChapterInfo(data).asLiveData()
 


### PR DESCRIPTION


![Screenshot_2023-07-28-10-21-51-193_org apphatchery gatbreferenceguide](https://github.com/AppHatchery/GATBReferenceGuide-Android/assets/17104217/e4965447-b548-48ce-9379-2a587b18e833)
The duplicates occurred because there was no control of the insertion of the cached data ,now we clear the databases that are cashed not user data so the new change don't multiply in the database *** i have just done it for all static Json data so if anyone changes them in the future all they have to do is change the BUILD NUMBER IN app\src\main\java\org\apphatchery\gatbreferenceguide\ui\fragments\MainFragment.kt

files changed:
app\src\main\java\org\apphatchery\gatbreferenceguide\db\dao\ChapterDao.kt app\src\main\java\org\apphatchery\gatbreferenceguide\db\dao\ChartDao.kt app\src\main\java\org\apphatchery\gatbreferenceguide\db\dao\GlobalSearchDao.kt app\src\main\java\org\apphatchery\gatbreferenceguide\db\dao\HtmlInfoDao.kt app\src\main\java\org\apphatchery\gatbreferenceguide\db\dao\SubChapterDao.kt app\src\main\java\org\apphatchery\gatbreferenceguide\db\Database.kt app\src\main\java\org\apphatchery\gatbreferenceguide\db\repositories\Repository.kt app\src\main\java\org\apphatchery\gatbreferenceguide\ui\fragments\MainFragment.kt app\src\main\java\org\apphatchery\gatbreferenceguide\ui\viewmodels\FAMainViewModel.kt


