### PR TITLE
Set Pendo identifier for release

### DIFF
--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/prefs/UserPrefs.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/prefs/UserPrefs.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.createDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -19,12 +20,18 @@ class UserPrefs @Inject constructor(
 
     companion object {
         val BUILD_VERSION = intPreferencesKey("BUILD_VERSION")
+        val PENDO_VISITOR_ID = stringPreferencesKey("PENDO_VISITOR_ID")
     }
 
 
     suspend fun setBuildVersion(version: Int) =
         dataStore.edit { it[BUILD_VERSION] = version }
 
+    suspend fun setPendoVisitorId(id: String) =
+        dataStore.edit { it[PENDO_VISITOR_ID] = id }
+
     val getBuildVersion: Flow<Int> = dataStore.data.map { it[BUILD_VERSION] ?: 1 }
+
+    val getPendoVisitorId: Flow<String> = dataStore.data.map { it[PENDO_VISITOR_ID] ?: "" }
 
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/MainFragment.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/MainFragment.kt
@@ -30,10 +30,12 @@ import org.apphatchery.gatbreferenceguide.ui.adapters.FAMainFirst6ChartAdapter
 import org.apphatchery.gatbreferenceguide.ui.viewmodels.FAMainViewModel
 import org.apphatchery.gatbreferenceguide.utils.*
 import sdk.pendo.io.Pendo
+import java.util.UUID
 import javax.inject.Inject
 
 
 private const val BUILD_VERSION = 7
+private const val PENDO_RELEASE_VERSION = "August-23-"
 
 @AndroidEntryPoint
 class MainFragment : BaseFragment(R.layout.fragment_main) {
@@ -45,23 +47,25 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
     private lateinit var predefinedChartList: ArrayList<ChartAndSubChapter>
     private val htmlInfoEntity = ArrayList<HtmlInfoEntity>()
     private val viewModel: FAMainViewModel by viewModels()
+    private var visitor_id: String? = null
 
     @Inject
     lateinit var userPrefs: UserPrefs
 
     companion object {
-        const val VISITOR_ID = ""
+        //const val VISITOR_ID = ""
         const val ACCOUNT_ID = "GTRG"
     }
-
     private fun setupPendo() = Pendo.startSession(
-        VISITOR_ID,
+        visitor_id,
         ACCOUNT_ID,
         null,
         null
     )
 
     private fun init() {
+
+        visitor_id = getVisitorId()
 
         with(fragmentMainBinding) {
             progressBar.isVisible = false
@@ -322,6 +326,7 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
                     FAMainViewModel.Callback.InsertGlobalSearchInfoComplete -> {
                         viewLifecycleOwner.lifecycleScope.launch {
                             userPrefs.setBuildVersion(BUILD_VERSION)
+                            userPrefs.setPendoVisitorId(getVisitorId())
                         }
                         init()
                     }
@@ -330,4 +335,17 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
         }
     }
 
+    private fun generatePendoVisitorId() = PENDO_RELEASE_VERSION + UUID.randomUUID().toString()
+
+    private fun getVisitorId(): String {
+        var id = ""
+        userPrefs.getPendoVisitorId.asLiveData().observe(viewLifecycleOwner){
+            if(it.isEmpty()){
+                id = generatePendoVisitorId()
+                viewLifecycleOwner.lifecycleScope.launch{ userPrefs.setPendoVisitorId(id) }
+            }
+            if (it.isNotEmpty()) id = it
+        }
+        return id
+    }
 }


### PR DESCRIPTION
Added custom Pendo identifier for the August 2023 maintenance release.

The ID is being saved in the user's preferences and called upon initialisation, if the ID is null then the ID will be generated and saved then retrieved

### Example of ID

![image](https://github.com/AppHatchery/GATBReferenceGuide-Android/assets/42870528/9d0d804c-6a2c-4422-bbec-a35260379548)
