### PR TITLE
prevent keyboard from lifting the bottom navbar

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
 
         <activity android:name=".ui.MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustPan"
             >
             <intent-filter>
 


### PR DESCRIPTION
File changed
GATBReferenceGuide-Android\app\src\main\AndroidManifest.xml

```
<activity android:name=".ui.MainActivity"
            android:exported="true"
            android:windowSoftInputMode="adjustPan"
            >
```
![image](https://github.com/AppHatchery/GATBReferenceGuide-Android/assets/17104217/efa825f4-296d-40bf-8085-fd6564ce7905)
