### PR TITLE
search filter changed to All when users clears texts and starts again

### DIFF
--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/GlobalSearchFragment.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/GlobalSearchFragment.kt
@@ -432,6 +432,12 @@ class GlobalSearchFragment : BaseFragment(R.layout.fragment_global_search) {
         searchJob?.cancel()
         val trimmedText = text.trim()
         viewModel.searchQuery.value = text
+
+        if(trimmedText.isBlank()){
+            currentTab = 0
+            bind.tabLayout.getTabAt(0)?.select()
+        }
+
         with(bind.searchItemCount) {
             visibility = if (trimmedText.isBlank()) View.GONE else View.VISIBLE
         }
@@ -445,6 +451,10 @@ class GlobalSearchFragment : BaseFragment(R.layout.fragment_global_search) {
             suggestedContent.visibility = if (isBlank) View.VISIBLE else View.GONE
             tabLayout.visibility = if (isBlank) View.GONE else View.VISIBLE
             tabLayoutContainer.visibility = if (isBlank) View.GONE else View.VISIBLE
+
+            if(isBlank){
+                recyclerview.scrollToPosition(0)
+            }
         }
     }
 


### PR DESCRIPTION
# User stays on the same tab

### Problem
Delete a search query and make a new one; it stays on the same tab, even if there are results on the All tab. This can lead the user to think there are no results at all.

### Solution
Check if the search string is blank, and if it is, set the current tab to All so that when the user starts typing, the search results start from the All tab

### Changes
### Modified the handleSearchTextChange function
![image](https://github.com/user-attachments/assets/b6604959-dadb-48d0-a2e0-7f4b4af3b744)
### Modified the updateSearchViewVisibility function
![image](https://github.com/user-attachments/assets/102a4099-e521-43f1-bc17-1e82f5acf031)

### How it works

1. Check the search string to see if it's empty
2. Set the current tab index to 0 if it is empty
3. Get the tab layout for index 0 and display it

### Testing

- [ ] Verify that when the search term is deleted/cleared with the clear button in the search bar and a new one is placed, the tab view is set to All when displaying results.
- [ ] Verify that when the search term is deleted through the keyboard backspace and a new one is written, the tab view is set to All when the results are displayed.