### PR TITLE
fix: collapsed not bug

### DIFF
--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/BodyFragment.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/BodyFragment.kt
@@ -435,6 +435,10 @@ class BodyFragment : BaseFragment(R.layout.fragment_body) {
 
 
             fun expandRecyclerView(recyclerView: RecyclerView) {
+
+                recyclerView.layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT
+                recyclerView.requestLayout()
+
                 recyclerView.measure(
                     ViewGroup.LayoutParams.MATCH_PARENT,
                     ViewGroup.LayoutParams.WRAP_CONTENT
@@ -450,12 +454,15 @@ class BodyFragment : BaseFragment(R.layout.fragment_body) {
                         recyclerView.layoutParams.height = animation.animatedValue as Int
                         recyclerView.requestLayout()
                     }
+                    doOnEnd {
+                        recyclerView.layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT
+                    }
                 }
                 animator.start()
             }
 
             fun collapseRecyclerView(recyclerView: RecyclerView) {
-                val initialHeight = recyclerView.measuredHeight
+                val initialHeight = recyclerView.height
 
                 val animator = ValueAnimator.ofInt(initialHeight, 0).apply {
                     duration = 300
@@ -463,7 +470,11 @@ class BodyFragment : BaseFragment(R.layout.fragment_body) {
                         recyclerView.layoutParams.height = animation.animatedValue as Int
                         recyclerView.requestLayout()
                     }
-                    doOnEnd { recyclerView.visibility = View.GONE }
+                    doOnEnd {
+                        recyclerView.visibility = View.GONE
+
+                        recyclerView.layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT
+                    }
                 }
                 animator.start()
             }


### PR DESCRIPTION
## Problem
long note it appears full-sized, then if you collapse it and expand it, it cuts the note, and you can no longer view the whole note

## Solution
make the note scrollable when it has expended, after it has been collapsed to allow the user to simply scroll through the long note. similar to when you first view the long note.

## Changes
### Modified the BodyFragment.kt file under expandedRecylerView function
![image](https://github.com/user-attachments/assets/39cc46d9-6b4e-4eca-9d15-bde0d8597df1)
![image](https://github.com/user-attachments/assets/0cf328d6-6ce3-4077-b519-47217a63198e)
### Modified the BodyFragment.kt file under collapseRecylerView function
![image](https://github.com/user-attachments/assets/435c99dd-4eb2-4a6b-860f-8c97d0ee3e18)

## How it works

1. Reset the height of the RecyclerView when expanding and collapsing. 
2. Use the current height of the data list instead of the measured height. 
3. Display the expanded data in RecyclerView to allow scrolling in the view. list.

## Testing
Create a very long note, collapse the note, and then expand it again. Verify you can still scroll through the note
