### PR TITLE
Revert "updated from API 34 to 35 in TB Guide android UI Updates"

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -7,7 +7,7 @@
         <DropdownSelection timestamp="2025-10-08T12:08:12.471238Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/oxygenalliance/.android/avd/Pixel_9_Pro_XL.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=13111JEC215706" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,12 +11,12 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk 34
 
     defaultConfig {
         applicationId "org.apphatchery.gatbreferenceguide"
         minSdk 24
-        targetSdk 35
+        targetSdk 34
         versionCode 34
         versionName "1.13"
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
-
+<resources>
     <style name="heading1" parent="@android:style/TextAppearance.Small">
         <item name="android:fontFamily">@font/inter_bold</item>
         <item name="android:textSize">36sp</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,9 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.GATBReferenceGuide" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-       <!-- edge-to-edge opt-out for API 35 -->
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
-        <item name="android:statusBarColor" tools:targetApi="l">@color/reddish</item>
         <item name="android:windowBackground">#F9F9F9</item>
         <item name="chapterBackgroundColorGrey">@android:color/white</item>
         <item name="chapterBackgroundColorWhite">#F9F9F9</item>


### PR DESCRIPTION
Reverts AppHatchery/GATBReferenceGuide-Android#136 because API 35 edge-to-edge  opt out option is not working on Android 16