### PR TITLE
144 Fix Broken internal and External Links 

### DIFF
--- a/app/src/main/assets/pages/11_community_tuberculosis_control__c__tb_case_definitions_for_public_health_surveillance.html
+++ b/app/src/main/assets/pages/11_community_tuberculosis_control__c__tb_case_definitions_for_public_health_surveillance.html
@@ -27,8 +27,8 @@
         <hr>
     </div>
     <p class="uk-paragraph">GDPH utilizes the 2009 Council of State and Territorial Epidemiologists (CSTE) case definition for tuberculosis (Position Statement 09-ID-65) that can be accessed at: <a
-                href="https://wwwn.cdc.gov/nndss/conditions/tuberculosis/case-definition/2009/" class="res-width">
-            https://wwwn.cdc.gov/nndss/conditions/tuberculosis/case-definition/2009/</a></p>
+            href="https://ndc.services.cdc.gov/case-definitions/tuberculosis-2009/" class="res-width">
+        https://ndc.services.cdc.gov/case-definitions/tuberculosis-2009/</a></p>
     <b class="toggle-title" onclick="toggleItem(this)"><span>Clinical Criteria</span><span class="chevron-up">⌃</span></b>
     <div class="item">
         <p>A case that meets all of the following criteria:</p>

--- a/app/src/main/assets/pages/11_community_tuberculosis_control__g__curetb_program_(internation_linkage_to_tb_care).html
+++ b/app/src/main/assets/pages/11_community_tuberculosis_control__g__curetb_program_(internation_linkage_to_tb_care).html
@@ -141,9 +141,9 @@
         <p>
             Phone: (619) 542-4013
         </p>
-        <p>
-            GDPH utilizes the 2009 Council of State and Territorial Epidemiologists (CSTE) case definition for tuberculosis (Position Statement 09-ID-65) that can be accessed at: <a href="https://ndc.services.cdc.gov/case-definitions/tuberculosis-2009/https://ndc.services.cdc.gov/case-definitions/tuberculosis-2009/">https://ndc.services.cdc.gov/case-definitions/tuberculosis-2009/https://ndc.services.cdc.gov/case-definitions/tuberculosis-2009/</a>
-        </p>
+         <p>
+             GDPH utilizes the 2009 Council of State and Territorial Epidemiologists (CSTE) case definition for tuberculosis (Position Statement 09-ID-65) that can be accessed at: <a href="https://ndc.services.cdc.gov/case-definitions/tuberculosis-2009/">https://ndc.services.cdc.gov/case-definitions/tuberculosis-2009/</a>
+         </p>
      </div>
 
     <span class="toggle-title" onclick="toggleItem(this)"><b>Clinical case definition</b>—A case that meets all of the following criteria:<span class="chevron-up">⌃</span></span>

--- a/app/src/main/assets/pages/2_diagnostic_tests_for_latent_tb_infection_(ltbi)__e__interferon_y_release_assays_(igras).html
+++ b/app/src/main/assets/pages/2_diagnostic_tests_for_latent_tb_infection_(ltbi)__e__interferon_y_release_assays_(igras).html
@@ -151,8 +151,8 @@
     <p>
         <b>Source</b>: Based on manufacturer recommendations for QuantiFERON-TB Gold Plus [Package insert]. <br>Available
         at:
-        <a href="https://www.qiagen.com/us/resources/resource?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en" class="res-width">
-            https://www.qiagen.com/us/resources/resource?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en</a>
+        <a href="https://www.qiagen.com/us/resources/download.aspx?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en" class="res-width">
+            https://www.qiagen.com/us/resources/download.aspx?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en</a>
     </p>
     
     <h4 id="table2" class="custom-table-title">Table 2. Interpretation Criteria for the T-SPOT.TB Test (T-Spot)</h4>

--- a/app/src/main/assets/pages/table_16_when_to_start_hiv_therapy.html
+++ b/app/src/main/assets/pages/table_16_when_to_start_hiv_therapy.html
@@ -16,7 +16,7 @@
 
 <body>
 <div class="uk-container">
-    <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="5_treatment_of_current_(active)_disease_therapy__g__antiretroviral_therapy_(art)_and_treatment_of_persons.html/#table16"> Antiretroviral Therapy (ART) and Treatment of Persons Living with HIV and Active TB </a></p>
+    <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="5_treatment_of_current_(active)_disease_therapy__f__tb_and_hiv.html#table16"> Antiretroviral Therapy (ART) and Treatment of Persons Living with HIV and Active TB </a></p>
     <p class="last-updated"><i>Last Updated October 2025</i></p>
     <hr>
     <div class="uk-overflow-auto"

--- a/app/src/main/assets/pages/table_16_when_to_start_hiv_therapy.html
+++ b/app/src/main/assets/pages/table_16_when_to_start_hiv_therapy.html
@@ -16,7 +16,7 @@
 
 <body>
 <div class="uk-container">
-    <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="5_treatment_of_current_(active)_disease_therapy__f__tb_and_hiv.html#table16"> Antiretroviral Therapy (ART) and Treatment of Persons Living with HIV and Active TB </a></p>
+    <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="5_treatment_of_current_(active)_disease_therapy__f__tb_and_hiv.html"> Antiretroviral Therapy (ART) and Treatment of Persons Living with HIV and Active TB </a></p>
     <p class="last-updated"><i>Last Updated October 2025</i></p>
     <hr>
     <div class="uk-overflow-auto"

--- a/app/src/main/assets/pages/table_17_what_to_start_choice_of_tb_therapy_and_antiretroviral_therapy_(art)_when)treating_co-infected_patients.html
+++ b/app/src/main/assets/pages/table_17_what_to_start_choice_of_tb_therapy_and_antiretroviral_therapy_(art)_when)treating_co-infected_patients.html
@@ -16,7 +16,7 @@
 
 <body>
 <div class="uk-container">
-    <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="5_treatment_of_current_(active)_disease_therapy__f__tb_and_hiv.html#table17"> Antiretroviral Therapy (ART) and Treatment of Persons Living with HIV and Active TB </a></p>
+    <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="5_treatment_of_current_(active)_disease_therapy__f__tb_and_hiv.html"> Antiretroviral Therapy (ART) and Treatment of Persons Living with HIV and Active TB </a></p>
     <div class="uk-overflow-auto"
          id="table_17_what_to_start_choice_of_tb_therapy_and_antiretroviral_therapy_(art)_when)treating_co-infected_patients">
         <table class="uk-table uk-table-small uk-table-divider">

--- a/app/src/main/assets/pages/table_17_what_to_start_choice_of_tb_therapy_and_antiretroviral_therapy_(art)_when)treating_co-infected_patients.html
+++ b/app/src/main/assets/pages/table_17_what_to_start_choice_of_tb_therapy_and_antiretroviral_therapy_(art)_when)treating_co-infected_patients.html
@@ -16,7 +16,7 @@
 
 <body>
 <div class="uk-container">
-    <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="5_treatment_of_current_(active)_disease_therapy__g__antiretroviral_therapy_(art)_and_treatment_of_persons.html/#table17"> Antiretroviral Therapy (ART) and Treatment of Persons Living with HIV and Active TB </a></p>
+    <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="5_treatment_of_current_(active)_disease_therapy__f__tb_and_hiv.html#table17"> Antiretroviral Therapy (ART) and Treatment of Persons Living with HIV and Active TB </a></p>
     <div class="uk-overflow-auto"
          id="table_17_what_to_start_choice_of_tb_therapy_and_antiretroviral_therapy_(art)_when)treating_co-infected_patients">
         <table class="uk-table uk-table-small uk-table-divider">

--- a/app/src/main/assets/pages/table_17_what_to_start_choice_of_tb_therapy_and_antiretroviral_therapy_(art)_when_treating_co-infected_patients.html
+++ b/app/src/main/assets/pages/table_17_what_to_start_choice_of_tb_therapy_and_antiretroviral_therapy_(art)_when_treating_co-infected_patients.html
@@ -16,7 +16,7 @@
 
 <body>
 <div class="uk-container">
-    <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="5_treatment_of_current_(active)_disease_therapy__g__antiretroviral_therapy_(art)_and_treatment_of_persons.html/#table17"> Antiretroviral Therapy (ART) and Treatment of Persons Living with HIV and Active TB </a></p>
+    <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="5_treatment_of_current_(active)_disease_therapy__f__tb_and_hiv.html"> Antiretroviral Therapy (ART) and Treatment of Persons Living with HIV and Active TB </a></p>
     <p class="last-updated"><i>Last Updated June 2024</i></p>
     <hr>
     <div class="uk-overflow-auto"


### PR DESCRIPTION
###Overview

This pull request updates several external resource links and internal cross-references in the HTML assets to ensure accuracy and maintain consistency across the documentation. The changes include corrections to URLs for tuberculosis case definitions, a manufacturer resource link, and internal chapter references for tables related to HIV and TB treatment.

**External resource link updates:**

* Updated the tuberculosis case definition link in `11_community_tuberculosis_control__c__tb_case_definitions_for_public_health_surveillance.html` to the current CDC URL.
* Fixed the duplicated URL for the tuberculosis case definition in `11_community_tuberculosis_control__g__curetb_program_(internation_linkage_to_tb_care).html` to the correct CDC resource.
* Changed the QuantiFERON-TB Gold Plus manufacturer resource link in `2_diagnostic_tests_for_latent_tb_infection_(ltbi)__e__interferon_y_release_assays_(igras).html` to the proper download page.

**Internal cross-reference corrections:**

* Updated the chapter reference for Table 16 in `table_16_when_to_start_hiv_therapy.html` to point to the correct HIV and TB treatment section.
* Updated the chapter reference for Table 17 in `table_17_what_to_start_choice_of_tb_therapy_and_antiretroviral_therapy_(art)_when)treating_co-infected_patients.html` to point to the correct section.