### PR TITLE
 Fix bottom-nav interaction on Bookmarks screen

### DIFF
--- a/app/src/main/assets/pages/10_tb_infection_control_hospital_isolation_procedures__c__environmental_controls.html
+++ b/app/src/main/assets/pages/10_tb_infection_control_hospital_isolation_procedures__c__environmental_controls.html
@@ -18,7 +18,7 @@
         <div class="chapter-header">
             <div class="header-title">
                 <div>
-                    <img src="ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
+                    <img src="../assets/ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
                 </div>
                 <p class="chapter-title">X. TB Infection Control: Hospital Isolation Procedures</p>
             </div>
@@ -28,8 +28,8 @@
     </div>
     <p class="uk-paragraph">
         Patients admitted to health care facilities with suspected or confirmed TB should be placed in an airborne
-        infection isolation (AII) room (i.e., negative pressure rooms with <u>&gt;</u> 6 air changes per hour;
-        <u>&gt;</u> 12 for new construction); air from AII rooms should be exhausted directly to the outside or through
+        infection isolation (AII) room (i.e., negative pressure rooms with <u>></u> 6 air changes per hour;
+        <u>></u> 12 for new construction); air from AII rooms should be exhausted directly to the outside or through
         a HEPA filter before being recirculated.</p>
 </div>
 </body>

--- a/app/src/main/assets/pages/2_diagnostic_tests_for_latent_tb_infection_(ltbi)__e__interferon_y_release_assays_(igras).html
+++ b/app/src/main/assets/pages/2_diagnostic_tests_for_latent_tb_infection_(ltbi)__e__interferon_y_release_assays_(igras).html
@@ -19,7 +19,7 @@
         <div class="chapter-header">
             <div class="header-title">
                 <div>
-                    <img src="ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
+                    <img src="../assets/ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
                 </div>
                 <p class="chapter-title">II. Diagnostic Tests for Latent TB Infection (LTBI)</p>
             </div>
@@ -68,93 +68,93 @@
 
         <table id="tab-content0" class="uk-table uk-table-small tab-content active-tab">
             <tbody>
-                <tr>
-                    <th>Nil (IU/ml)</th>
-                    <td colspan="2"> &lt; 8.0</td>
-                </tr>
-                <tr>
-                    <th class="uk-text-nowrap">TB1 minus Nil (IU/ml)</th>
-                    <td>&gt; 0.35 and &gt; 25% of Nil</td>
-                    <td>Any</td>
-                </tr>
-                <tr>
-                    <th class="uk-text-nowrap">TB2 minus Nil (IU/ml)</th>
-                    <td>Any</td>
-                    <td>&gt; 0.35 and &gt; 25% of Nil</td>
-                </tr>
-                <tr>
-                    <th>Mitogen minus Nil</th>
-                    <td colspan="2">Any</td>
-                </tr>
-                <tr>
-                    <th>Report/Interpretation</th>
-                    <td colspan="2">M. <i>tuberculosis </i>infection likely</td>
-                </tr>
+            <tr>
+                <th>Nil (IU/ml)</th>
+                <td colspan="2"> &lt; 8.0</td>
+            </tr>
+            <tr>
+                <th class="uk-text-nowrap">TB1 minus Nil (IU/ml)</th>
+                <td>> 0.35 and > 25% of Nil</td>
+                <td>Any</td>
+            </tr>
+            <tr>
+                <th class="uk-text-nowrap">TB2 minus Nil (IU/ml)</th>
+                <td>Any</td>
+                <td>> 0.35 and > 25% of Nil</td>
+            </tr>
+            <tr>
+                <th>Mitogen minus Nil</th>
+                <td colspan="2">Any</td>
+            </tr>
+            <tr>
+                <th>Report/Interpretation</th>
+                <td colspan="2">M. <i>tuberculosis </i>infection likely</td>
+            </tr>
             </tbody>
         </table>
 
-<table id="tab-content1" class="uk-table uk-table-small uk-table-divider tab-content">
+        <table id="tab-content1" class="uk-table uk-table-small uk-table-divider tab-content">
 
-             <tbody>
-                <tr>
-                    <th colspan="2">Nil (IU/ml)</th>
-                    <td colspan="2"> &lt; 8.0</td>
-                </tr>
-                <tr>
-                    <th colspan="2">TB1 minus Nil (IU/ml)</th>
-                    <td colspan="2">< 0.35 or > 0.35 and < 25 % of Nil</td>
-                </tr>
-                <tr>
-                    <th colspan="2">TB2 minus Nil (IU/ml)</th>
-                    <td colspan="2">< 0.35 or > 0.35 and < 25% of Nil</td>
-                </tr>
-                <tr>
-                    <th colspan="2">Mitogen minus Nil</th>
-                    <td colspan="2"> > 0.50</td>
-                </tr>
-                <tr>
-                    <th colspan="2">Report/Interpretation</th>
-                    <td colspan="2">M. <i>tuberculosis </i>infection not likely</td>
-                </tr>
+            <tbody>
+            <tr>
+                <th colspan="2">Nil (IU/ml)</th>
+                <td colspan="2"> &lt; 8.0</td>
+            </tr>
+            <tr>
+                <th colspan="2">TB1 minus Nil (IU/ml)</th>
+                <td colspan="2">< 0.35 or > 0.35 and < 25 % of Nil</td>
+            </tr>
+            <tr>
+                <th colspan="2">TB2 minus Nil (IU/ml)</th>
+                <td colspan="2">< 0.35 or > 0.35 and < 25% of Nil</td>
+            </tr>
+            <tr>
+                <th colspan="2">Mitogen minus Nil</th>
+                <td colspan="2"> > 0.50</td>
+            </tr>
+            <tr>
+                <th colspan="2">Report/Interpretation</th>
+                <td colspan="2">M. <i>tuberculosis </i>infection not likely</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content2" class="uk-table tab-content">
             <tbody>
-                <tr>
-                    <th>Nil (IU/ml)</th>
-                    <td> &lt; 8.0</td>
-                    <td>&gt; 8.0</td>
-                </tr>
-                <tr>
-                    <th class="uk-text-nowrap">TB1 minus Nil (IU/ml)</th>
-                    <td>< 0.35 or > 0.35 and < 25% of Nil</td>
-                    <td>Any</td>
-                </tr>
-                <tr>
-                    <th class="uk-text-nowrap">TB2 minus Nil (IU/ml)</th>
-                    <td>< 0.35 or > 0.35 and < 25% of Nil</td>
-                    <td>Any</td>
-                </tr>
-                <tr>
-                    <th>Mitogen minus Nil</th>
-                    <td> &lt; 0.50</td>
-                    <td>Any</td>
-                </tr>
-                <tr>
-                    <th>Report/Interpretation</th>
-                    <td colspan="2">Likelihood of M. <i>tuberculosis </i>infection cannot be determined</td>
-                </tr>
+            <tr>
+                <th>Nil (IU/ml)</th>
+                <td> &lt; 8.0</td>
+                <td>> 8.0</td>
+            </tr>
+            <tr>
+                <th class="uk-text-nowrap">TB1 minus Nil (IU/ml)</th>
+                <td>< 0.35 or > 0.35 and < 25% of Nil</td>
+                <td>Any</td>
+            </tr>
+            <tr>
+                <th class="uk-text-nowrap">TB2 minus Nil (IU/ml)</th>
+                <td>< 0.35 or > 0.35 and < 25% of Nil</td>
+                <td>Any</td>
+            </tr>
+            <tr>
+                <th>Mitogen minus Nil</th>
+                <td> &lt; 0.50</td>
+                <td>Any</td>
+            </tr>
+            <tr>
+                <th>Report/Interpretation</th>
+                <td colspan="2">Likelihood of M. <i>tuberculosis </i>infection cannot be determined</td>
+            </tr>
             </tbody>
         </table>
     </div>
     <p>
         <b>Source</b>: Based on manufacturer recommendations for QuantiFERON-TB Gold Plus [Package insert]. <br>Available
         at:
-        <a href="https://www.qiagen.com/us/resources/resource?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en" class="res-width">
-            https://www.qiagen.com/us/resources/resource?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en</a>
+        <a href="https://www.qiagen.com/us/resources/download.aspx?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en" class="res-width">
+            https://www.qiagen.com/us/resources/download.aspx?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en</a>
     </p>
-    
+
     <h4 id="table2" class="custom-table-title">Table 2. Interpretation Criteria for the T-SPOT.TB Test (T-Spot)</h4>
     <div class="uk-overflow-auto" id="table2">
         <div class="uk-tabs-container">
@@ -168,72 +168,72 @@
 
         <table id="option-content0" class="uk-table tab-content option-content active-option">
             <tbody>
-                <tr>
-                    <th colspan="1">Nil*</th>
-                    <td colspan="1">&le; 10 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">TB Response&dagger;</th>
-                    <td colspan="1">&ge; 8 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">Mitogen&sect;</th>
-                    <td colspan="1">Any</td>
-                </tr>
+            <tr>
+                <th colspan="1">Nil*</th>
+                <td colspan="1">&le; 10 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">TB Response†</th>
+                <td colspan="1">&ge; 8 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">Mitogen&sect;</th>
+                <td colspan="1">Any</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="option-content1" class="uk-table tab-content option-content">
             <tbody>
-                <tr>
-                    <th colspan="1">Nil*</th>
-                    <td colspan="1">&lt; 10 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">TB Response&dagger;</th>
-                    <td colspan="1">5, 6, or 7 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">Mitogen&sect;</th>
-                    <td colspan="1">Any</td>
-                </tr>
+            <tr>
+                <th colspan="1">Nil*</th>
+                <td colspan="1">&lt; 10 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">TB Response†</th>
+                <td colspan="1">5, 6, or 7 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">Mitogen&sect;</th>
+                <td colspan="1">Any</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="option-content2" class="uk-table tab-content option-content">
             <tbody>
-                <tr>
-                    <th colspan="1">Nil*</th>
-                    <td colspan="1">&le; 10 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">TB Response&dagger;</th>
-                    <td colspan="1">&gt; 20 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">Mitogen&sect;</th>
-                    <td colspan="1">&gt; 20 spots</td>
-                </tr>
+            <tr>
+                <th colspan="1">Nil*</th>
+                <td colspan="1">&le; 10 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">TB Response†</th>
+                <td colspan="1">> 20 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">Mitogen&sect;</th>
+                <td colspan="1">> 20 spots</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="option-content3" class="uk-table tab-content option-content">
             <tbody>
-                <tr>
-                    <th colspan="1">Nil*</th>
-                    <td colspan="1">&le; 10 spots</td>
-                    <td colspan="1">&le; 10 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">TB Response&dagger;</th>
-                    <td colspan="1">Any</td>
-                    <td colspan="1">< 5 spots</td>
-                </tr>
-                <tr>
-                    <th class="uk-table-small" colspan="1">Mitogen&sect;</th>
-                    <td colspan="1">Any</td>
-                    <td colspan="1">< 20 spots</td>
-                </tr>
+            <tr>
+                <th colspan="1">Nil*</th>
+                <td colspan="1">&le; 10 spots</td>
+                <td colspan="1">&le; 10 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">TB Response†</th>
+                <td colspan="1">Any</td>
+                <td colspan="1">< 5 spots</td>
+            </tr>
+            <tr>
+                <th class="uk-table-small" colspan="1">Mitogen&sect;</th>
+                <td colspan="1">Any</td>
+                <td colspan="1">< 20 spots</td>
+            </tr>
             </tbody>
         </table>
 

--- a/app/src/main/assets/pages/2_diagnostic_tests_for_latent_tb_infection_(ltbi)__f__targeted_testing_and_diagnostic_tests_for_ltbi.html
+++ b/app/src/main/assets/pages/2_diagnostic_tests_for_latent_tb_infection_(ltbi)__f__targeted_testing_and_diagnostic_tests_for_ltbi.html
@@ -19,7 +19,7 @@
         <div class="chapter-header">
             <div class="header-title">
                 <div>
-                    <img src="ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
+                    <img src="../assets/ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
                 </div>
                 <p class="chapter-title">II. Diagnostic Tests for Latent TB Infection (LTBI)</p>
             </div>
@@ -35,28 +35,28 @@
         disease (see <a href="#table3">Table 3</a>).
     </p>
     <img src="../assets/image_3.png">
-    <b class="toggle-title" onclick="toggleItem(this)"><span>People living with HIV who have LTBI</span><span class="chevron-up">⌃</span></b>    
+    <b class="toggle-title" onclick="toggleItem(this)"><span>People living with HIV who have LTBI</span><span class="chevron-up">⌃</span></b>
     <div class="item">
         <ul>
             <li>are at the greatest risk of progressing to active TB disease (at rates up to 8 -10% per year). All persons living with HIV should undergo testing for LTBI, and if LTBI is found, should strongly be encouraged to initiate and complete treatment for LTBI.</li>
         </ul>
     </div>
 
-    <b class="toggle-title" onclick="toggleItem(this)"><span>Patients who take immunomodulating drugs</span><span class="chevron-up">⌃</span></b>    
+    <b class="toggle-title" onclick="toggleItem(this)"><span>Patients who take immunomodulating drugs</span><span class="chevron-up">⌃</span></b>
     <div class="item">
         <ul>
             <li>are also at increased risk for progression to active TB disease if infected with M. tuberculosis. This includes patients with LTBI who are treated with TNF-α inhibitors such as infliximab (Remicade), etanercept (Enbrel), adalimumab (Humira), certolizumab pegol (Cimzia), or golimumab (Simponi). Following the initial introduction of TNF-α inhibitor drugs, there were reports of the subsequent development of extrapulmonary and disseminated disease and in some cases, death.</li>
         </ul>
     </div>
 
-    <b class="toggle-title" onclick="toggleItem(this)"><span>All patients who will be treated with TNF-α inhibitor drugs</span><span class="chevron-up">⌃</span></b>    
+    <b class="toggle-title" onclick="toggleItem(this)"><span>All patients who will be treated with TNF-α inhibitor drugs</span><span class="chevron-up">⌃</span></b>
     <div class="item">
         <ul>
             <li>should be screened for LTBI before starting the medication; if found to have LTBI, they should be started on therapy for LTBI (after active TB disease is excluded) before starting the TNF-α inhibitor. Whether treatment for LTBI should be completed before a TNF-α inhibitor is started is controversial.</li>
         </ul>
     </div>
 
-    <b class="toggle-title" onclick="toggleItem(this)"><span>Patients preparing to receive a solid organ transplant</span><span class="chevron-up">⌃</span></b>    
+    <b class="toggle-title" onclick="toggleItem(this)"><span>Patients preparing to receive a solid organ transplant</span><span class="chevron-up">⌃</span></b>
     <div class="item">
         <ul>
             <li>should also be screened for LTBI.</li>
@@ -64,7 +64,7 @@
         </ul>
     </div>
 
-    <b class="toggle-title" onclick="toggleItem(this)"><span>Current clinical practice among experts is to use targeted testing for LTBI based on epidemiologic risk factors.</span><span class="chevron-up">⌃</span></b>    
+    <b class="toggle-title" onclick="toggleItem(this)"><span>Current clinical practice among experts is to use targeted testing for LTBI based on epidemiologic risk factors.</span><span class="chevron-up">⌃</span></b>
     <div class="item">
         <ul>
             <li>Children less than 5 years of age are at increased risk for progression to active TB disease if infected but should not be tested for LTBI unless they are at increased risk for TB exposure (see <a href="#table3">Table 3</a> ).</li>
@@ -77,65 +77,65 @@
     </div>
 
     <p class="uk-paragraph"> Who should be targeted for LTBI testing? </p>
-   
+
     <p class="uk-paragraph">Diagnostic tests for LTBI are not recommended for people with low risk of M. tuberculosis infection. Testing of low-risk persons can result in false-positive tests.
     </p>
-       
-   <b class="toggle-title" onclick="toggleItem(this)"><span>Certain persons with increased risk of developing TB if they have LTBI should be targeted for testing. These include:</span><span class="chevron-up">⌃</span></b>  
+
+    <b class="toggle-title" onclick="toggleItem(this)"><span>Certain persons with increased risk of developing TB if they have LTBI should be targeted for testing. These include:</span><span class="chevron-up">⌃</span></b>
     <div class="item">
         <ul class="uk-list uk-list-disc">
-        <li>People who have spent time with someone who has TB disease (contacts of active TB cases)</li>
-        <li>People living with HIV or those who have other immunecompromising illnesses.</li>
-        <li>
-            Immigrants from high TB incidence countries (e.g., Asia, Africa, most countries in Latin America, the Caribbean, Eastern Europe, and Russia)
-        </li>
-        <li>People who live or work somewhere in the United States where TB disease is more common (homeless shelters,
-            correctional facilities including prisons and jails, or some nursing homes)
-        </li>
-        <li>People with substance use disorders including persons who inject drugs</li>
-        <li>People who are preparing to initiate treatment with a TNF-α inhibitor.</li>
-        <li>People preparing to receive a solid organ transplant or hematopoetic stem cell transplant.</li>
+            <li>People who have spent time with someone who has TB disease (contacts of active TB cases)</li>
+            <li>People living with HIV or those who have other immunecompromising illnesses.</li>
+            <li>
+                Immigrants from high TB incidence countries (e.g., Asia, Africa, most countries in Latin America, the Caribbean, Eastern Europe, and Russia)
+            </li>
+            <li>People who live or work somewhere in the United States where TB disease is more common (homeless shelters,
+                correctional facilities including prisons and jails, or some nursing homes)
+            </li>
+            <li>People with substance use disorders including persons who inject drugs</li>
+            <li>People who are preparing to initiate treatment with a TNF-α inhibitor.</li>
+            <li>People preparing to receive a solid organ transplant or hematopoetic stem cell transplant.</li>
         </ul>
     </div>
     <h4 class="toggle-title" onclick="toggleItem(this)"><span>U.S. Preventive Services Task Force (USPSTF) Recommendations for Screening for Latent TB Infection
         (LTBI):</span><span class="chevron-up">⌃</span></h4>
     <div class="item">
-    <ul>
-        <li>The U.S. Preventive Services Task Force (USPSTF) recommends
-    testing populations that are at increased risk for TB infection
-    <p>
-        <a href="https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/latent-tuberculosis-infection-screening" class="res-width">
-            (https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/latent-tuberculosis-infection-screening)</a>
-    </p>
-    </li>
-    <li>
-    This is a “B” recommendation (“offer or provide this
-    service”) indicating that given the current evidence, the USPSTF
-    has concluded with moderate certainty that benefits of screening
-    for LTBI in people who are at increased risk of infection outweigh
-    the potential harms.</li>
+        <ul>
+            <li>The U.S. Preventive Services Task Force (USPSTF) recommends
+                testing populations that are at increased risk for TB infection
+                <p>
+                    <a href="https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/latent-tuberculosis-infection-screening" class="res-width">
+                        (https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/latent-tuberculosis-infection-screening)</a>
+                </p>
+            </li>
+            <li>
+                This is a “B” recommendation (“offer or provide this
+                service”) indicating that given the current evidence, the USPSTF
+                has concluded with moderate certainty that benefits of screening
+                for LTBI in people who are at increased risk of infection outweigh
+                the potential harms.</li>
 
-    <li>
-        However, the highest-risk populations and thus those with the greatest benefit for targeted screening and treatment (persons living with HIV, close contacts of persons with active TB, and those being treated with immunosuppressive
-        agents such as TNF-α inhibitors) were excluded from the USPSTF
-        review of evidence because “screening in these populations may
-        be considered standard care as part of disease management or
-        indicated prior to the use of certain medications.”
-    </li>
+            <li>
+                However, the highest-risk populations and thus those with the greatest benefit for targeted screening and treatment (persons living with HIV, close contacts of persons with active TB, and those being treated with immunosuppressive
+                agents such as TNF-α inhibitors) were excluded from the USPSTF
+                review of evidence because “screening in these populations may
+                be considered standard care as part of disease management or
+                indicated prior to the use of certain medications.”
+            </li>
 
-    <li>
-        Once these highest-risk groups which should be screened for LTBI are removed, patients considered high risk in the primary
-        care setting that should be screened for LTBI include non-U.S. born persons
-        who have immigrated to the U.S. from high burden TB countries.
-    </li>
+            <li>
+                Once these highest-risk groups which should be screened for LTBI are removed, patients considered high risk in the primary
+                care setting that should be screened for LTBI include non-U.S. born persons
+                who have immigrated to the U.S. from high burden TB countries.
+            </li>
 
-    <li>
-        <b>
-            High-risk groups for TB infection that should be targeted for
-            testing and treatment are outlined above and also listed in
-            <a id="table3">Table 3</a>. </b>
-    </li>
-    </ul>
+            <li>
+                <b>
+                    High-risk groups for TB infection that should be targeted for
+                    testing and treatment are outlined above and also listed in
+                    <a id="table3">Table 3</a>. </b>
+            </li>
+        </ul>
     </div>
 
     <h4 id="table3" class="custom-table-title">Table 3. High Prevalence and High-Risk Groups</h4>
@@ -143,13 +143,13 @@
         <table class="uk-table uk-table-small uk-table-divider">
             <tbody>
             <tr>
-                <th>Groups with a High Prevalence of Latent TB Infection&nbsp;</th>
+                <th>Groups with a High Prevalence of Latent TB Infection </th>
                 <th>Groups with a High Risk of Progression to Active TB Disease if <u>Infected</u> with M.
                     <i>tuberculosis</i></th>
             </tr>
             <tr>
                 <td>Persons born in countries with high rates of TB</td>
-                <td>Persons living with HIV Persons who are close contacts of persons with infectious active TB&nbsp;
+                <td>Persons living with HIV Persons who are close contacts of persons with infectious active TB
                 </td>
             </tr>
             <tr>
@@ -159,7 +159,7 @@
             <tr>
                 <td>Persons who live or spend time in certain facilities (e.g., nursing homes, correctional
                     institutions,
-                    homeless shelters, drug treatment centers)&nbsp;
+                    homeless shelters, drug treatment centers)
                 </td>
                 <td>Persons with recent infection with M. tuberculosis (e.g., have had a diagnostic test result for LTBI
                     convert to positive in the past 1-2 years) Persons who have chest radiographs suggestive of old TB
@@ -172,7 +172,7 @@
             <tr>
                 <td colspan="2">*Diabetes mellitus, silicosis, prolonged therapy with corticosteroids, immunosuppressive
                     therapy particularly TNF-&alpha; blockers, leukemia, Hodgkin&rsquo;s disease, head and neck cancers,
-                    severe kidney disease, certain intestinal conditions, malnutrition&nbsp;
+                    severe kidney disease, certain intestinal conditions, malnutrition
                 </td>
             </tr>
             </tbody>
@@ -186,7 +186,7 @@
             tests can yield different results. Studies which employed multiple
             diagnostic tests have demonstrated that discordant test results
             are not uncommon.</p>
-            <img src="../assets/image_3.png">
+        <img src="../assets/image_3.png">
 
         <p class="uk-paragraph">Which diagnostic test for LTBI should be used? </p>
         <b class="toggle-title" onclick="toggleItem(this)"><span>General Recommendations for Use of Diagnostic Tests for LTBI: </span><span class="chevron-up">⌃</span></b>
@@ -247,35 +247,35 @@
         </div>
         <b class="toggle-title" onclick="toggleItem(this)"><span>Situations in which a TST or IGRA may be used without preference: </span><span class="chevron-up">⌃</span></b>
         <div class="item">
-        <ul class="uk-list uk-list-disc">
-            <li>Contact investigations (i.e., testing of recent contacts of persons known or suspected to have active TB disease)
-            </li>
-        </ul>
+            <ul class="uk-list uk-list-disc">
+                <li>Contact investigations (i.e., testing of recent contacts of persons known or suspected to have active TB disease)
+                </li>
+            </ul>
         </div>
 
         <b class="toggle-title" onclick="toggleItem(this)"><span>Situations in which testing with both an IGRA and a TST may be
             considered: </span><span class="chevron-up">⌃</span></b>
         <div class="item">
-        <ul class="uk-list uk-list-disc">
-            <li>When additional evidence of infection is required to encourage a person that they have LTBI and should take and adhere to therapy for LTBI (e.g., non-US born health care worker who believes that their positive TST result is attributable to BCG)
-            </li>
-            <li>When the initial diagnostic test performed in a healthy person at low risk for both infection and
-                progression is positive
-                (and thought to be a false positive). This situation could be
-                prevented by using targeted testing and not testing low risk
-                individuals.
-            </li>
-            <li>Repeating an IGRA or performing a TST might be useful
-                when the initial IGRA result is indeterminate, borderline, or
-                invalid and a reason for testing persists.
-            </li>
-            <li>In selected very high-risk individuals when missing the presence of LTBI could have serious consequences
-                (e.g., individuals to be started on a TNF-α blocker or other immunocompromising medications).
-            </li>
-        </ul>
-    </div>
+            <ul class="uk-list uk-list-disc">
+                <li>When additional evidence of infection is required to encourage a person that they have LTBI and should take and adhere to therapy for LTBI (e.g., non-US born health care worker who believes that their positive TST result is attributable to BCG)
+                </li>
+                <li>When the initial diagnostic test performed in a healthy person at low risk for both infection and
+                    progression is positive
+                    (and thought to be a false positive). This situation could be
+                    prevented by using targeted testing and not testing low risk
+                    individuals.
+                </li>
+                <li>Repeating an IGRA or performing a TST might be useful
+                    when the initial IGRA result is indeterminate, borderline, or
+                    invalid and a reason for testing persists.
+                </li>
+                <li>In selected very high-risk individuals when missing the presence of LTBI could have serious consequences
+                    (e.g., individuals to be started on a TNF-α blocker or other immunocompromising medications).
+                </li>
+            </ul>
+        </div>
 
-</div>
+    </div>
 </body>
 
 <script src="../assets/uikit.js" type="text/javascript"></script>

--- a/app/src/main/assets/pages/3_treatment_of_latent_tb_infection_(ltbi)__a__treatment_regimens.html
+++ b/app/src/main/assets/pages/3_treatment_of_latent_tb_infection_(ltbi)__a__treatment_regimens.html
@@ -19,7 +19,7 @@
         <div class="chapter-header">
             <div class="header-title">
                 <div>
-                    <img src="ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
+                    <img src="../assets/ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
                 </div>
                 <p class="chapter-title">III. Treatment of Latent TB Infection (LTBI)</p>
             </div>
@@ -43,13 +43,13 @@
             </b>
 
             <div class="item">
-            Rifampin for 4 months is a preferred CDC treatment regimen for the treatment of LTBI among persons presumed to be infected with drug-susceptible TB (isoniazid [INH] and rifampin susceptible) and is the regimen of choice for the treatment of LTBI among persons thought to be infected with INH-resistant strains 
-            of M. tuberculosis. Rifampin is also preferred by many clinicians and public health clinics because of the shorter duration of therapy compared to INH and because rifampin has less hepatotoxicity compared to INH for the treatment of LTBI.
+                Rifampin for 4 months is a preferred CDC treatment regimen for the treatment of LTBI among persons presumed to be infected with drug-susceptible TB (isoniazid [INH] and rifampin susceptible) and is the regimen of choice for the treatment of LTBI among persons thought to be infected with INH-resistant strains
+                of M. tuberculosis. Rifampin is also preferred by many clinicians and public health clinics because of the shorter duration of therapy compared to INH and because rifampin has less hepatotoxicity compared to INH for the treatment of LTBI.
 
-            Rifampin for 4 months has been shown to be noninferior to 9 months of INH for the treatment of LTBI in a randomized controlled trial. In addition, rifampin was associated with higher completion rates and fewer adverse effects compared to INH. Rifampin has a large number of drug -drug interactions (as discussed on page 78) 
-            including warfarin, oral contraceptives, azole antifungals, and HIV antiretroviral therapy. Other medications that a person with LTBI is taking is an important consideration when determining whether rifampin or other LTBI regimens which include rifampin or other rifamycins can be prescribed. Drug-drug interactions between
-             rifamycins and antiretroviral therapy are regularly updated by the U.S. Department of Health and Human Services 
-               (for LTBI regimens and rifampin/rifamycins: <a href="https://clinicalinfo.hiv.gov/en/guidelines/hiv-clinical-guidelines-adult-and-adolescent-opportunistic-infections/mycobacterium">https://clinicalinfo.hiv.gov/en/guidelines/hiv-clinical-guidelines-adult-and-adolescent-opportunistic-infections/mycobacterium</a> );
+                Rifampin for 4 months has been shown to be noninferior to 9 months of INH for the treatment of LTBI in a randomized controlled trial. In addition, rifampin was associated with higher completion rates and fewer adverse effects compared to INH. Rifampin has a large number of drug -drug interactions (as discussed on page 78)
+                including warfarin, oral contraceptives, azole antifungals, and HIV antiretroviral therapy. Other medications that a person with LTBI is taking is an important consideration when determining whether rifampin or other LTBI regimens which include rifampin or other rifamycins can be prescribed. Drug-drug interactions between
+                rifamycins and antiretroviral therapy are regularly updated by the U.S. Department of Health and Human Services
+                (for LTBI regimens and rifampin/rifamycins: <a href="https://clinicalinfo.hiv.gov/en/guidelines/hiv-clinical-guidelines-adult-and-adolescent-opportunistic-infections/mycobacterium">https://clinicalinfo.hiv.gov/en/guidelines/hiv-clinical-guidelines-adult-and-adolescent-opportunistic-infections/mycobacterium</a> );
                 rifampin and antiretroviral drug interactions:<a href=" https://clinicalinfo.hiv.gov/sites/default/files/guidelines/documents/adult-adolescent-arv/guidelines-adult-adolescent-arv.pdf"> https://clinicalinfo.hiv.gov/sites/default/files/guidelines/documents/adult-adolescent-arv/guidelines-adult-adolescent-arv.pdf</a>
             </div>
         </li>
@@ -57,51 +57,51 @@
         <li><b class="toggle-title" onclick="toggleItem(this)"><span>INH plus Rifapentine (3HP)</span> <span class="chevron-up">⌃</span></b>
             <div class="item">
                 <p>A short course regimen of weekly INH plus rifapentine for 12 weekly doses is another CDC-preferred
-                     regimen for the treatment of LTBI (due to presumed infection with drug-susceptible M. tuberculosis) in adults as well as children > 2 years of age.
-                      In 2011, when CDC first recommended 3HP for the treatment of LTBI it indicated it should be delivered by directly observed therapy [DOT]. However, based on further studies and updated data, CDC revised guidelines for the use of 3HP in 2018 expanded the patient populations for which this regimen could be used and included an option for self-administration of the 3HP regimen. CDC recommendations for 3HP in the treatment of LTBI include:</p>
-                    <ul class="uk-list uk-list-disc">
-                        <li>use of 3HP in adults and persons aged 2–17 years with
-                            LTBI;
-                        </li>
-                        <li>use of 3HP in persons who are living with HIV with
-                            LTBI including those with AIDS and taking antiretroviral medications with acceptable drug-drug
-                            interactions with rifapentine* [the 2021 DHHS guidelines on treatment of HIV among adults and 
-                            adolescents indicate that rifapentine as part of a 3HP regimen is acceptable to use among persons 
-                            living with HIV on and ART regimen that includes once daily dolutegravir]; and
-                        </li>
-                        <li>
-                            use of 3HP by directly observed therapy (DOT) or self-administered 
-                            therapy (SAT) in persons aged ≥ 2
-                            years. Per CDC recommendations, “the health care
-                            provider should choose the mode of administration
-                            (DOT versus SAT) based on local practice, individual
-                            patient attributes and preferences, and other considerations, including risk for progression to
-                            severe
-                            forms of TB disease” (MMWR 2018; 67:723-72).
-        
-                        </li>
-                    </ul>
-                    <p>
-                       The 3HP is regimen is NOT recommended for pregnant women, children < 2 years old, persons living with HIV who are on antiretroviral
-                        drugs that have significant drug-drug interactions with rifapentine, or patients infected with suspected INH-resistant,
-                         rifampin-resistant, or multidrug resistant (MDR) isolates. Other potential challenges in using the 3HP regimen in addition to
-                          the drug-drug interactions due to rifapentine (similar to those seen with other rifamycin drugs such as rifampin) include cost of 
-                          medications that are greater than most alternatives; the need to take numerous pills simultaneously (10 pills once weekly
-                           compared with two or three pills daily for other regimens for most adults); and the association with a systemic drug
-                            reaction or influenza-like syndrome that can include syncope and hypotension (although the risk of hospitalization is low, 0.1% in published studies).
-                    </p>
+                    regimen for the treatment of LTBI (due to presumed infection with drug-susceptible M. tuberculosis) in adults as well as children > 2 years of age.
+                    In 2011, when CDC first recommended 3HP for the treatment of LTBI it indicated it should be delivered by directly observed therapy [DOT]. However, based on further studies and updated data, CDC revised guidelines for the use of 3HP in 2018 expanded the patient populations for which this regimen could be used and included an option for self-administration of the 3HP regimen. CDC recommendations for 3HP in the treatment of LTBI include:</p>
+                <ul class="uk-list uk-list-disc">
+                    <li>use of 3HP in adults and persons aged 2–17 years with
+                        LTBI;
+                    </li>
+                    <li>use of 3HP in persons who are living with HIV with
+                        LTBI including those with AIDS and taking antiretroviral medications with acceptable drug-drug
+                        interactions with rifapentine* [the 2021 DHHS guidelines on treatment of HIV among adults and
+                        adolescents indicate that rifapentine as part of a 3HP regimen is acceptable to use among persons
+                        living with HIV on and ART regimen that includes once daily dolutegravir]; and
+                    </li>
+                    <li>
+                        use of 3HP by directly observed therapy (DOT) or self-administered
+                        therapy (SAT) in persons aged ≥ 2
+                        years. Per CDC recommendations, “the health care
+                        provider should choose the mode of administration
+                        (DOT versus SAT) based on local practice, individual
+                        patient attributes and preferences, and other considerations, including risk for progression to
+                        severe
+                        forms of TB disease” (MMWR 2018; 67:723-72).
+
+                    </li>
+                </ul>
+                <p>
+                    The 3HP is regimen is NOT recommended for pregnant women, children < 2 years old, persons living with HIV who are on antiretroviral
+                    drugs that have significant drug-drug interactions with rifapentine, or patients infected with suspected INH-resistant,
+                    rifampin-resistant, or multidrug resistant (MDR) isolates. Other potential challenges in using the 3HP regimen in addition to
+                    the drug-drug interactions due to rifapentine (similar to those seen with other rifamycin drugs such as rifampin) include cost of
+                    medications that are greater than most alternatives; the need to take numerous pills simultaneously (10 pills once weekly
+                    compared with two or three pills daily for other regimens for most adults); and the association with a systemic drug
+                    reaction or influenza-like syndrome that can include syncope and hypotension (although the risk of hospitalization is low, 0.1% in published studies).
+                </p>
             </div>
         </li>
 
         <li><b class="toggle-title" onclick="toggleItem(this)"><span>Isoniazid (INH)</span> <span class="chevron-up">⌃</span></b>
             <div class="item">
                 <p>
-                   In the CDC 2020 LTBI treatment guidelines, 6 or 9 months of daily INH is a recommended alternative regimen for the treatment of 
-                   LTBI (due to presumed infection with drug susceptible M. tuberculosis) as shown in <a href="#table4">Table 4</a>. A regimen of 6 months of daily INH
-                    is strongly recommended for HIV-negative adults and children of all ages and conditionally recommended for adults living with 
-                    HIV and children of all ages; INH daily for 9 months is conditionally recommended for adults and children of all ages, both 
-                    HIV-seronegative and HIV-positive. One practical approach for the use of INH for LTBI is to aim for a 9 month regimen with the 
-                    goal of completion of at least 6 months. INH can be given daily (e.g., by self-administered therapy) as outlined in <a href="#table5">Table 5</a>. 
+                    In the CDC 2020 LTBI treatment guidelines, 6 or 9 months of daily INH is a recommended alternative regimen for the treatment of
+                    LTBI (due to presumed infection with drug susceptible M. tuberculosis) as shown in <a href="#table4">Table 4</a>. A regimen of 6 months of daily INH
+                    is strongly recommended for HIV-negative adults and children of all ages and conditionally recommended for adults living with
+                    HIV and children of all ages; INH daily for 9 months is conditionally recommended for adults and children of all ages, both
+                    HIV-seronegative and HIV-positive. One practical approach for the use of INH for LTBI is to aim for a 9 month regimen with the
+                    goal of completion of at least 6 months. INH can be given daily (e.g., by self-administered therapy) as outlined in <a href="#table5">Table 5</a>.
                     INH should be used for the treatment of LTBI when there are serious potential drug-drug interactions with rifampin or other rifamycins.
                 </p>
             </div>
@@ -109,17 +109,17 @@
 
         <li><b class="toggle-title" onclick="toggleItem(this)"><span>Isoniazid (INH) plus Rifampin</span> <span class="chevron-up">⌃</span></b>
             <div class="item">
-            A regimen of 3 months of
-            daily INH plus daily rifampin is a CDC conditionally recommended regimen for the treatment of LTBI in adults
-            and
-            children of all ages. Because this regimen contains rifampin,
-            clinicians must closely review other medications that a person with LTBI is on to assess whether there are
-            drug-drug
-            interactions that would prohibit the use of this regimen (as
-            discussed above for rifampin).
+                A regimen of 3 months of
+                daily INH plus daily rifampin is a CDC conditionally recommended regimen for the treatment of LTBI in adults
+                and
+                children of all ages. Because this regimen contains rifampin,
+                clinicians must closely review other medications that a person with LTBI is on to assess whether there are
+                drug-drug
+                interactions that would prohibit the use of this regimen (as
+                discussed above for rifampin).
             </div>
         </li>
-    </ul>   
+    </ul>
 
     <img src="../assets/image_3.png" alt="Pills" class="uk-align-center">
 
@@ -135,47 +135,47 @@
 
         <table id="tab-content0" class="uk-table uk-table-small uk-table-divider tab-content active-tab">
             <tbody>
-                <tr>
-                    <th>Regimes</th>
-                    <td>3 months isoniazid plus rifapentine given once weekly</td>
-                    <td>4 months rifampin given daily</td>
-                    <td>3 months isoniazid plus rifampin given daily</td>
-                </tr>
-                <tr>
-                    <th>Recommendation (Strong or Conditional)</th>
-                    <td>Strong</td>
-                    <td>Strong</td>
-                    <td>Conditional</td>
-                </tr>
-                <tr>
-                    <th>Evidence (High, Moderate, Low, or Very Low)</th>
-                    <td>Moderate</td>
-                    <td>Moderate (HIV negative) &dagger; </td>
-                    <td>Very low (HIV negative) &dagger; </td>
-                </tr>
+            <tr>
+                <th>Regimes</th>
+                <td>3 months isoniazid plus rifapentine given once weekly</td>
+                <td>4 months rifampin given daily</td>
+                <td>3 months isoniazid plus rifampin given daily</td>
+            </tr>
+            <tr>
+                <th>Recommendation (Strong or Conditional)</th>
+                <td>Strong</td>
+                <td>Strong</td>
+                <td>Conditional</td>
+            </tr>
+            <tr>
+                <th>Evidence (High, Moderate, Low, or Very Low)</th>
+                <td>Moderate</td>
+                <td>Moderate (HIV negative) † </td>
+                <td>Very low (HIV negative) † </td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content1" class="uk-table uk-table-small uk-table-divider tab-content">
             <tbody>
-                <tr>
-                    <th>Regimes</th>
-                    <td>6 months isoniazid given daily</td>
-                    <td>9 months isoniazid given daily</td>
-                    <td>3 months isoniazid plus rifampin given daily</td>
-                </tr>
-                <tr>
-                    <th>Recommendation (Strong or Conditional)</th>
-                    <td>Strong &sect;</td>
-                    <td>Conditional</td>
-                    <td>Conditional</td>
-                </tr>
-                <tr>
-                    <th>Evidence (High, Moderate, Low, or Very Low)</th>
-                    <td>Moderate (HIV negative)</td>
-                    <td>Moderate (if living with HIV)</td>
-                    <td>Moderate</td>
-                </tr>
+            <tr>
+                <th>Regimes</th>
+                <td>6 months isoniazid given daily</td>
+                <td>9 months isoniazid given daily</td>
+                <td>3 months isoniazid plus rifampin given daily</td>
+            </tr>
+            <tr>
+                <th>Recommendation (Strong or Conditional)</th>
+                <td>Strong &sect;</td>
+                <td>Conditional</td>
+                <td>Conditional</td>
+            </tr>
+            <tr>
+                <th>Evidence (High, Moderate, Low, or Very Low)</th>
+                <td>Moderate (HIV negative)</td>
+                <td>Moderate (if living with HIV)</td>
+                <td>Moderate</td>
+            </tr>
             </tbody>
         </table>
 
@@ -198,137 +198,137 @@
 
         <div class="uk-tabs-container">
             <ul class="tabs">
-                <li><button class="tab active-tab" onclick="switchTab(0, event)">Isoniazid* and rifapentine&dagger;</button></li>
-                <li><button class="tab" onclick="switchTab(1, event)">Rifampin&para;</button></li>
-                <li><button class="tab" onclick="switchTab(2, event)">Isoniazid* and rifampin&para;</button></li>
-                <li><button class="tab" onclick="switchTab(3, event)">Isoniazid*</button></li>
+                <li><button class="tab active-tab" onclick="switchTab(0, event)">Isoniazid and rifapentine</button></li>
+                <li><button class="tab" onclick="switchTab(1, event)">Rifampin</button></li>
+                <li><button class="tab" onclick="switchTab(2, event)">Isoniazid and rifampin</button></li>
+                <li><button class="tab" onclick="switchTab(3, event)">Isoniazid</button></li>
             </ul>
         </div>
 
         <table id="tab-content2" class="uk-table uk-table-small tab-content active-tab">
             <tbody>
-                <tr>
-                    <th>Duration</th>
-                    <td>3 months</td>
-                </tr>
-                <tr>
-                    <th>Dosage And Age Group</th>
-                    <td>
-                        <strong class="highlight">Adults and children aged &gt; 12 yrs</strong><br>
-                        <strong>Isoniazid:</strong><br>
-                        15 mg/kg rounded up to the nearest 50 or 100 mg; 900 mg maximum<br>
-                        <strong>Rifapentine:</strong><br>
-                        10 - 14.0 kg, 300 mg<br>
-                        14.1 - 25.0 kg, 450 mg<br>
-                        25. 1 - 32.0 kg, 600 mg<br>
-                        32.1 - 49.9 kg, 750 mg<br>
-                        &gt; 50.0 kg, 900 mg maximum&nbsp;<br>
-                        <br>
-                        <strong class="highlight">Children aged 2 - 11 yrs</strong><br>
-                        <strong>Isoniazid*</strong>: <br> 25 mg/kg; 900 mg maximum<br>
-                        <strong>Rifapentine&dagger;</strong>: <br>
-                        see above&nbsp;<br>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Frequency</th>
-                    <td>Once weekly</td>
-                </tr>
-                <tr>
-                    <th>Total doses</th>
-                    <td>12</td>
-                </tr>
+            <tr>
+                <th>Duration</th>
+                <td>3 months</td>
+            </tr>
+            <tr>
+                <th>Dosage And Age Group</th>
+                <td>
+                    <strong class="highlight">Adults and children aged ≥ 12 yrs</strong><br>
+                    <strong>Isoniazid:</strong><br>
+                    15 mg/kg rounded up to the nearest 50 or 100 mg; 900 mg maximum<br>
+                    <strong>Rifapentine:</strong><br>
+                    10 - 14.0 kg, 300 mg<br>
+                    14.1 - 25.0 kg, 450 mg<br>
+                    25. 1 - 32.0 kg, 600 mg<br>
+                    32.1 - 49.9 kg, 750 mg<br>
+                    > 50.0 kg, 900 mg maximum <br>
+                    <br>
+                    <strong class="highlight">Children aged 2 - 11 yrs</strong><br>
+                    <strong>Isoniazid*</strong>: <br> 25 mg/kg; 900 mg maximum<br>
+                    <strong>Rifapentine†</strong>: <br>
+                    see above <br>
+                </td>
+            </tr>
+            <tr>
+                <th>Frequency</th>
+                <td>Once weekly</td>
+            </tr>
+            <tr>
+                <th>Total doses</th>
+                <td>12</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content3" class="uk-table uk-table-small tab-content">
             <tbody>
-                <tr>
-                    <th>Duration</th>
-                    <td>4 months</td>
-                </tr>
-                <tr>
-                    <th>Dosage And Age Group</th>
-                    <td>
-                        <strong>Adults</strong>: 10 mg/kg<br>
-                        <strong>Children</strong>: 15 - 20 mg/kg**<br>
-                        <strong>Maximum dose</strong>: 600 mg<br>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Frequency</th>
-                    <td>Daily</td>
-                </tr>
-                <tr>
-                    <th>Total doses</th>
-                    <td>120</td>
-                </tr>
+            <tr>
+                <th>Duration</th>
+                <td>4 months</td>
+            </tr>
+            <tr>
+                <th>Dosage And Age Group</th>
+                <td>
+                    <strong>Adults</strong>: 10 mg/kg<br>
+                    <strong>Children</strong>: 15 - 20 mg/kg**<br>
+                    <strong>Maximum dose</strong>: 600 mg<br>
+                </td>
+            </tr>
+            <tr>
+                <th>Frequency</th>
+                <td>Daily</td>
+            </tr>
+            <tr>
+                <th>Total doses</th>
+                <td>120</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content4" class="uk-table uk-table-small tab-content">
             <tbody>
-                <tr>
-                    <th>Duration</th>
-                    <td>3 months</td>
-                </tr>
-                <tr>
-                    <th>Dosage And Age Group</th>
-                    <td>
-                        <strong class="highlight">Adults </strong> <br>
-                        <strong>Isoniazid*</strong>: <br> 5 mg/kg; 300 mg maximum <br>
-                        <strong>Rifampin&para;</strong>: <br> 10 mg/kg; 600 mg maximum <br><br>
-                        <strong class="highlight">Children</strong>: <br>
-                        <strong>Isoniazid*</strong>: <br> 10 - 20 mg/kg&dagger;&dagger; ; 300 mg maximum <br>
-                        <strong>Rifampin&para;</strong>: <br> 15 - 20 mg/kg; 600 mg maximum <br>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Frequency</th>
-                    <td>Daily</td>
-                </tr>
-                <tr>
-                    <th>Total doses</th>
-                    <td>90</td>
-                </tr>
+            <tr>
+                <th>Duration</th>
+                <td>3 months</td>
+            </tr>
+            <tr>
+                <th>Dosage And Age Group</th>
+                <td>
+                    <strong class="highlight">Adults </strong> <br>
+                    <strong>Isoniazid*</strong>: <br> 5 mg/kg; 300 mg maximum <br>
+                    <strong>Rifampin¶</strong>: <br> 10 mg/kg; 600 mg maximum <br><br>
+                    <strong class="highlight">Children</strong>: <br>
+                    <strong>Isoniazid*</strong>: <br> 10 - 20 mg/kg†† ; 300 mg maximum <br>
+                    <strong>Rifampin¶</strong>: <br> 15 - 20 mg/kg; 600 mg maximum <br>
+                </td>
+            </tr>
+            <tr>
+                <th>Frequency</th>
+                <td>Daily</td>
+            </tr>
+            <tr>
+                <th>Total doses</th>
+                <td>90</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content5" class="uk-table uk-table-small tab-content">
             <tbody>
-                <tr>
-                    <th>Duration</th>
-                    <td>9 months</td>
-                    <td>6 months</td>
-                </tr>
-                <tr>
-                    <th>Dosage And Age Group</th>
-                    <td>
-                        <strong>Adults</strong>: <br> 5 mg/kg <br>
-                        <strong>Children</strong>: <br> 10 - 20 mg/kg&dagger;&dagger; <br>
-                        <strong>Maximum dose</strong>: <br> 300 mg <br>
-                    </td>
-                    <td>
-                        <strong>Adults</strong>: <br> 5 mg/kg <br>
-                        <strong>Children</strong>: <br> 10 - 20 mg/kg&dagger;&dagger; <br>
-                        <strong>Maximum dose</strong>: <br> 300 mg <br>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Frequency</th>
-                    <td>Daily</td>
-                    <td>Daily</td>
-                </tr>
-                <tr>
-                    <th>Total doses</th>
-                    <td>270</td>
-                    <td>180</td>
-                </tr>
+            <tr>
+                <th>Duration</th>
+                <td>9 months</td>
+                <td>6 months</td>
+            </tr>
+            <tr>
+                <th>Dosage And Age Group</th>
+                <td>
+                    <strong>Adults</strong>: <br> 5 mg/kg <br>
+                    <strong>Children</strong>: <br> 10 - 20 mg/kg†† <br>
+                    <strong>Maximum dose</strong>: <br> 300 mg <br>
+                </td>
+                <td>
+                    <strong>Adults</strong>: <br> 5 mg/kg <br>
+                    <strong>Children</strong>: <br> 10 - 20 mg/kg†† <br>
+                    <strong>Maximum dose</strong>: <br> 300 mg <br>
+                </td>
+            </tr>
+            <tr>
+                <th>Frequency</th>
+                <td>Daily</td>
+                <td>Daily</td>
+            </tr>
+            <tr>
+                <th>Total doses</th>
+                <td>270</td>
+                <td>180</td>
+            </tr>
             </tbody>
         </table>
     </div>
 
-     <p>
+    <p>
         * Isoniazid is formulated as 100-mg and 300-mg tablets. † Rifapentine is formulated as 150-mg tablets in blister packs that should be kept sealed until use. Rifapentine should not be used for children &lt2 years of age due to lack of pharmacokinetic data.¶ Rifampin (rifampicin) is formulated as 150-mg and 300-mg capsules.   ** The American Academy of Pediatrics acknowledges that some experts use rifampin at 20 - 30 mg/kg for the daily regimen when prescribing for infants and toddlers. (Source: American Academy of Pediatrics. Tuberculosis. In: Kimberlin DW, Brady MT, Jackson MA, Long SS, eds. Red Book: 2018 Report of the Committee on Infectious Diseases. 31st ed. Itasca, IL: American Academy of Pediatrics; 2018:829-53). †† The American Academy of Pediatrics recommends an isoniazid dosage of 10 - 15 mg/kg for the daily regimen. Adapted from MMWR Recomm Rep 2020; 69(1):1-11.
     </p>
 
@@ -344,73 +344,73 @@
 
         <table id="tab-content6" class="uk-table uk-table-small tab-content active-tab">
             <tbody>
-                <tr>
-                    <th>Adverse Reactions</th>
-                    <td>
-                        Gastrointestinal (GI) upset, hepatic enzyme elevations, hepatitis, peripheral neuropathy, mild effects on central nervous system (CNS), drug interactions
-                    </td>
-                </tr>
-                <tr>
-                    <th>
-                        Monitoring
-                    </th>
-                    <td>
-                        Order baseline hepatic chemistry blood tests (at least AST or ALT) for patients with specific conditions: Living with HIV, liver disorders, postpartum period (&lt3 months after delivery), regular alcohol use, injection drug use, or use of medications with known possible interactions. [Some clinicians prefer to obtain baseline tests on all adults]. Repeat measurements if: * baseline results are abnormal * client is at high-risk for adverse reactions * client has symptoms of adverse reactions
-                    </td>
-                </tr>
-                <tr>
-                    <th>
-                        Comments
-                    </th>
-                    <td>
-                        Hepatitis risk increases with age and alcohol consumption. Pyridoxine can prevent isoniazid-induced peripheral neuropathy.
-                    </td>
-                </tr>
+            <tr>
+                <th>Adverse Reactions</th>
+                <td>
+                    Gastrointestinal (GI) upset, hepatic enzyme elevations, hepatitis, peripheral neuropathy, mild effects on central nervous system (CNS), drug interactions
+                </td>
+            </tr>
+            <tr>
+                <th>
+                    Monitoring
+                </th>
+                <td>
+                    Order baseline hepatic chemistry blood tests (at least AST or ALT) for patients with specific conditions: Living with HIV, liver disorders, postpartum period (&lt3 months after delivery), regular alcohol use, injection drug use, or use of medications with known possible interactions. [Some clinicians prefer to obtain baseline tests on all adults]. Repeat measurements if: * baseline results are abnormal * client is at high-risk for adverse reactions * client has symptoms of adverse reactions
+                </td>
+            </tr>
+            <tr>
+                <th>
+                    Comments
+                </th>
+                <td>
+                    Hepatitis risk increases with age and alcohol consumption. Pyridoxine can prevent isoniazid-induced peripheral neuropathy.
+                </td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content7" class="uk-table uk-table-small tab-content">
             <tbody>
-                <tr>
-                    <th>Adverse Reactions</th>
-                    <td>
-                        Orange discoloration of body fluids (secretions, tears, urine) , GI upset, drug interactions, hepatitis, thrombocytopenia, rash, fever, influenza-like symptoms, hypersensitivity reaction* Many drug-drug interactions
-                    </td>
-                </tr>
-                <tr>
-                    <th>
-                        Monitoring
-                    </th>
-                    <td>
-                        Complete blood count (CBC), platelets and liver function tests.
-                        Repeat measurements if: * baseline results are abnormal * client has symptoms of adverse reactions  Prior to starting RIF or RPT: need to carefully review all medications being taken by the patient with LTBI and ensure there is no contraindication to the use of that medication and RIF, RBT or RPT.
-                    </td>
-                </tr>
-                <tr>
-                    <th>
-                        Comments
-                    </th>
-                    <td>
-                        Hepatitis risk increases with age and alcohol consumption. Rifampin monotherapy is associated with lower risk of hepatotoxicity compared to INH monotherapy for patients being treated for LTBI. Need to carefully review for possible drug-drug interactions prior to starting RIF, RBT or RPT and ensure there are no contraindications to these agents prior to using them for the treatment of LTBI.                    </td>
-                </tr>
+            <tr>
+                <th>Adverse Reactions</th>
+                <td>
+                    Orange discoloration of body fluids (secretions, tears, urine) , GI upset, drug interactions, hepatitis, thrombocytopenia, rash, fever, influenza-like symptoms, hypersensitivity reaction* Many drug-drug interactions
+                </td>
+            </tr>
+            <tr>
+                <th>
+                    Monitoring
+                </th>
+                <td>
+                    Complete blood count (CBC), platelets and liver function tests.
+                    Repeat measurements if: * baseline results are abnormal * client has symptoms of adverse reactions  Prior to starting RIF or RPT: need to carefully review all medications being taken by the patient with LTBI and ensure there is no contraindication to the use of that medication and RIF, RBT or RPT.
+                </td>
+            </tr>
+            <tr>
+                <th>
+                    Comments
+                </th>
+                <td>
+                    Hepatitis risk increases with age and alcohol consumption. Rifampin monotherapy is associated with lower risk of hepatotoxicity compared to INH monotherapy for patients being treated for LTBI. Need to carefully review for possible drug-drug interactions prior to starting RIF, RBT or RPT and ensure there are no contraindications to these agents prior to using them for the treatment of LTBI.                    </td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content8" class="uk-table uk-table-small tab-content">
             <tbody>
-                <tr>
-                    <th>Adverse Reactions</th>
-                    <td>See adverse effects associated with isoniazid alone and a rifamycin alone (see above)</td>
-                </tr>
-                <tr>
-                    <th>Monitoring</th>
-                    <td>Complete blood count (CBC), platelets and liver function tests.
-                        Repeat measurements if: * baseline results are abnormal * client has symptoms of adverse reactions  Prior to starting RIF or RPT: need to carefully review all medications being taken by the patient with LTBI and ensure there is no contraindication to the use of that medication and RIF or RPT.</td>
-                </tr>
-                <tr>
-                    <th>Comments</th>
-                    <td>Approximately 4% of all patients using 3HP experience flu-like or other systemic drug reactions, with fever, headache, dizziness, nausea, muscle and bone pain, rash, itching, red eyes, or other symptoms. Approximately 5% of persons discontinue 3HP because of adverse events, including systemic drug reactions; these reactions typically occur after the first 3–4 doses, and begin approximately 4 hours after ingestion of medication.</td>
-                </tr>
+            <tr>
+                <th>Adverse Reactions</th>
+                <td>See adverse effects associated with isoniazid alone and a rifamycin alone (see above)</td>
+            </tr>
+            <tr>
+                <th>Monitoring</th>
+                <td>Complete blood count (CBC), platelets and liver function tests.
+                    Repeat measurements if: * baseline results are abnormal * client has symptoms of adverse reactions  Prior to starting RIF or RPT: need to carefully review all medications being taken by the patient with LTBI and ensure there is no contraindication to the use of that medication and RIF or RPT.</td>
+            </tr>
+            <tr>
+                <th>Comments</th>
+                <td>Approximately 4% of all patients using 3HP experience flu-like or other systemic drug reactions, with fever, headache, dizziness, nausea, muscle and bone pain, rash, itching, red eyes, or other symptoms. Approximately 5% of persons discontinue 3HP because of adverse events, including systemic drug reactions; these reactions typically occur after the first 3–4 doses, and begin approximately 4 hours after ingestion of medication.</td>
+            </tr>
             </tbody>
         </table>
     </div>

--- a/app/src/main/assets/pages/5_treatment_of_current_(active)_disease_therapy__a__considerations.html
+++ b/app/src/main/assets/pages/5_treatment_of_current_(active)_disease_therapy__a__considerations.html
@@ -18,7 +18,7 @@
         <div class="chapter-header">
             <div class="header-title">
                 <div>
-                    <img src="ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
+                    <img src="../assets/ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
                 </div>
                 <p class="chapter-title">V. Treatment of Current (Active) Disease Therapy</p>
             </div>
@@ -37,7 +37,7 @@
             with (or assume responsibility for if the clinician prefers) managing the TB treatment. The TB program can
             also
             provide access to TB experts throughout the state. <strong>Contact information for TB coordinators in each
-                county is found in the <a href="15_appendix_district_tb_coordinators_(by_district).html"> Appendix</a> and at</strong> &nbsp;the <i>Georgia</i> <a
+                county is found in the <a href="15_appendix_district_tb_coordinators_(by_district).html"> Appendix</a> and at</strong>  the <i>Georgia</i> <a
                     href="https://dph.georgia.gov/public-health-districts">DPH website </a></li>
 
 

--- a/app/src/main/assets/pages/5_treatment_of_current_(active)_disease_therapy__e__monitoring_patients_on_therapy_for_response_and_adverse_events.html
+++ b/app/src/main/assets/pages/5_treatment_of_current_(active)_disease_therapy__e__monitoring_patients_on_therapy_for_response_and_adverse_events.html
@@ -19,7 +19,7 @@
         <div class="chapter-header">
             <div class="header-title">
                 <div>
-                    <img src="ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
+                    <img src="../assets/ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
                 </div>
                 <p class="chapter-title">V. Treatment of Current (Active) Disease Therapy</p>
             </div>
@@ -38,7 +38,7 @@
                     <li>
                         Patients with cavitary pulmonary TB who have a positive 2-month sputum culture are at increased risk for relapse if treated with only 6 months of therapy for drug-susceptible TB. If the 2-month culture remains positive or if symptoms do not resolve, request repeat drug susceptibility testing to evaluate for acquired drug resistance. Additionally, review information
 
-related to treatment adherence. For any patient receiving self-administered therapy (this should be very rare as DOT is our standard of care) who has a positive 2-month culture, DOT should be initiated.
+                        related to treatment adherence. For any patient receiving self-administered therapy (this should be very rare as DOT is our standard of care) who has a positive 2-month culture, DOT should be initiated.
                     </li>
                     <li>
                         For patients with drug-susceptible active TB disease who have positive 2-month culture and have cavitary disease on their initial CXR, the continuation phase should be increased to 7 months so that they receive a total of 9 months of therapy.
@@ -71,7 +71,7 @@ related to treatment adherence. For any patient receiving self-administered ther
                         symptoms suggesting drug toxicity occur, appropriate laboratory testing should be performed to confirm or exclude
                         such toxicity. Patients should be instructed to report symptoms of hepatitis (which can be induced by
                         INH, RIF and/or PZA) immediately. Such symptoms include nausea, loss of appetite, vomiting, jaundice (dark
-                        urine, yellow skin), malaise, unexplained fever for &gt; 3 days, or abdominal tenderness. If patients have
+                        urine, yellow skin), malaise, unexplained fever for > 3 days, or abdominal tenderness. If patients have
                         jaundice or symptoms of liver disease, discontinue medications immediately and consult a specialist.
                     </li>
                     <li>

--- a/app/src/main/assets/pages/5_treatment_of_current_(active)_disease_therapy__f__tb_and_hiv.html
+++ b/app/src/main/assets/pages/5_treatment_of_current_(active)_disease_therapy__f__tb_and_hiv.html
@@ -339,7 +339,7 @@
                 </li>
                 <li>
                     Rifampin and rifabutin can be given with certain integrase inhibitors (<a
-                        href="https://clinicalinfo.hiv.gov/en/guidelines/hiv-clinical-guidelines-adult-and-adolescent-arv/drug-interactions-insti)">https://clinicalinfo.hiv.gov/en/guidelines/hiv-clinical-guidelines-adult-and-adolescent-arv/drug-interactions-insti)</a>.
+                        href="https://clinicalinfo.hiv.gov/en/guidelines/hiv-clinical-guidelines-adult-and-adolescent-arv/coinfections-tuberculosis-hiv">https://clinicalinfo.hiv.gov/en/guidelines/hiv-clinical-guidelines-adult-and-adolescent-arv/coinfections-tuberculosis-hiv</a>.
                 </li>
             </ul>
         </div>

--- a/app/src/main/assets/pages/9_bcg_vaccination.html
+++ b/app/src/main/assets/pages/9_bcg_vaccination.html
@@ -19,7 +19,7 @@
         <div class="chapter-header">
             <div class="header-title">
                 <div>
-                    <img src="ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
+                    <img src="../assets/ic_chapter.svg" width="16" height="16" class="ic_chapter_icon">
                 </div>
                 <p class="chapter-title">IX. BCG Vaccination</p>
             </div>
@@ -30,36 +30,36 @@
     <p class="uk-paragraph">
         Bacille Calmette-Guerin (BCG) vaccine is one of the most commonly used vaccines in the world and is given in
         the vast majority of low- and middle-income countries. </p>
-        
-        <p class="uk-paragraph">BCG is recommended in higher TB incidence areas because
+
+    <p class="uk-paragraph">BCG is recommended in higher TB incidence areas because
         it has a documented protective effect against TB meningitis and disseminated TB in young children. It does not
         prevent primary infection and, more importantly, does not prevent reactivation of latent pulmonary infection,
         the principal source of bacillary spread in the community.
-        </p>
-        <p class="uk-paragraph"> The impact of BCG vaccination on
+    </p>
+    <p class="uk-paragraph"> The impact of BCG vaccination on
         transmission of <i>M. tuberculosis </i>is therefore very limited (or there is no impact). BCG has not impacted
         the global epidemiology of TB. Because of variable efficacy, <i>BCG is NOT recommended for use in the U.S.
-    </i>
+        </i>
     </p>
     <img src="../assets/image_1.png">
     <p class="uk-paragraph">
         BCG is not a contraindication to a TST but as noted there can be cross reactions between BCG and the TST.
         The primary advantage of IGRAs is that they do not cross react with BCG. Interpretation of a tuberculin skin
         test reaction is not changed for patients who have received BCG.</p>
-    
-    <b class="toggle-title" onclick="toggleItem(this)"><span>A reaction of <u>&gt;</u> 10 mm (<u>&gt;</u>
+
+    <b class="toggle-title" onclick="toggleItem(this)"><span>A reaction of <u>></u> 10 mm (<u>></u>
         5mm in HIV-infected persons) of induration should be considered infection with <i>M. tuberculosis </i>because:</span><span class="chevron-up">⌃</span></b>
     <div class="item">
-    <ul>
-        <li>Conversion rates after BCG vaccination are not 100%;</li>
-        <li>The mean reaction size among BCG vaccines are often less than 10 mm (a large reaction is more
-            likely to be due to infection with M. tuberculosis than BCG vaccination);
-        </li>
-        <li>Tuberculin sensitivity tends to wane considerably after BCG vaccination; and,</li>
-        <li>BCG is usually given in high TB incidence countries, so assume that the
-            reaction is from infection, not vaccination.
-        </li>
-    </ul>
+        <ul>
+            <li>Conversion rates after BCG vaccination are not 100%;</li>
+            <li>The mean reaction size among BCG vaccines are often less than 10 mm (a large reaction is more
+                likely to be due to infection with M. tuberculosis than BCG vaccination);
+            </li>
+            <li>Tuberculin sensitivity tends to wane considerably after BCG vaccination; and,</li>
+            <li>BCG is usually given in high TB incidence countries, so assume that the
+                reaction is from infection, not vaccination.
+            </li>
+        </ul>
     </div>
     <p class="uk-paragraph">
         Since many BCG-vaccinated persons come from areas of high TB incidence, it is important that persons with a

--- a/app/src/main/assets/pages/table_1_interpretation_criteria_for_the_quantiferon_tb_gold_plus_test.html
+++ b/app/src/main/assets/pages/table_1_interpretation_criteria_for_the_quantiferon_tb_gold_plus_test.html
@@ -18,7 +18,7 @@
     <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="2_diagnostic_tests_for_latent_tb_infection_(ltbi)__e__interferon_y_release_assays_(igras).html#table1"> Interferon-y Release Assays (IGRAs) </a></p>
     <p class="last-updated"><i>Last Updated October 2025</i></p>
     <hr>
-     <div class="uk-overflow-auto" id="table_1_interpretation_criteria_for_the_quantiferon_tb_gold_plus_test">
+    <div class="uk-overflow-auto" id="table_1_interpretation_criteria_for_the_quantiferon_tb_gold_plus_test">
         <div class="uk-tabs-container">
             <ul class="tabs">
                 <li><button class="tab active-tab" onclick="switchTab(0, event)">Positive</button></li>
@@ -27,85 +27,85 @@
             </ul>
         </div>
 
-                <table id="tab-content0" class="uk-table uk-table-small tab-content active-tab">
+        <table id="tab-content0" class="uk-table uk-table-small tab-content active-tab">
             <tbody>
-                <tr>
-                    <th>Nil (IU/ml)</th>
-                    <td colspan="2"> &lt; 8.0</td>
-                </tr>
-                <tr>
-                    <th class="uk-text-nowrap">TB1 minus Nil (IU/ml)</th>
-                    <td>&gt; 0.35 and &gt; 25% of Nil</td>
-                    <td>Any</td>
-                </tr>
-                <tr>
-                    <th class="uk-text-nowrap">TB2 minus Nil (IU/ml)</th>
-                    <td>Any</td>
-                    <td>&gt; 0.35 and &gt; 25% of Nil</td>
-                </tr>
-                <tr>
-                    <th>Mitogen minus Nil</th>
-                    <td colspan="2">Any</td>
-                </tr>
-                <tr>
-                    <th>Report/Interpretation</th>
-                    <td colspan="2">M. <i>tuberculosis </i>infection likely</td>
-                </tr>
+            <tr>
+                <th>Nil (IU/ml)</th>
+                <td colspan="2"> &lt; 8.0</td>
+            </tr>
+            <tr>
+                <th class="uk-text-nowrap">TB1 minus Nil (IU/ml)</th>
+                <td>> 0.35 and > 25% of Nil</td>
+                <td>Any</td>
+            </tr>
+            <tr>
+                <th class="uk-text-nowrap">TB2 minus Nil (IU/ml)</th>
+                <td>Any</td>
+                <td>> 0.35 and > 25% of Nil</td>
+            </tr>
+            <tr>
+                <th>Mitogen minus Nil</th>
+                <td colspan="2">Any</td>
+            </tr>
+            <tr>
+                <th>Report/Interpretation</th>
+                <td colspan="2">M. <i>tuberculosis </i>infection likely</td>
+            </tr>
             </tbody>
         </table>
 
-<table id="tab-content1" class="uk-table uk-table-small uk-table-divider tab-content">
+        <table id="tab-content1" class="uk-table uk-table-small uk-table-divider tab-content">
 
-             <tbody>
-                <tr>
-                    <th colspan="2">Nil (IU/ml)</th>
-                    <td colspan="2"> &lt; 8.0</td>
-                </tr>
-                <tr>
-                    <th colspan="2">TB1 minus Nil (IU/ml)</th>
-                    <td colspan="2">< 0.35 or > 0.35 and < 25 % of Nil</td>
-                </tr>
-                <tr>
-                    <th colspan="2">TB2 minus Nil (IU/ml)</th>
-                    <td colspan="2">< 0.35 or > 0.35 and < 25% of Nil</td>
-                </tr>
-                <tr>
-                    <th colspan="2">Mitogen minus Nil</th>
-                    <td colspan="2"> > 0.50</td>
-                </tr>
-                <tr>
-                    <th colspan="2">Report/Interpretation</th>
-                    <td colspan="2">M. <i>tuberculosis </i>infection not likely</td>
-                </tr>
+            <tbody>
+            <tr>
+                <th colspan="2">Nil (IU/ml)</th>
+                <td colspan="2"> &lt; 8.0</td>
+            </tr>
+            <tr>
+                <th colspan="2">TB1 minus Nil (IU/ml)</th>
+                <td colspan="2">< 0.35 or > 0.35 and < 25 % of Nil</td>
+            </tr>
+            <tr>
+                <th colspan="2">TB2 minus Nil (IU/ml)</th>
+                <td colspan="2">< 0.35 or > 0.35 and < 25% of Nil</td>
+            </tr>
+            <tr>
+                <th colspan="2">Mitogen minus Nil</th>
+                <td colspan="2"> > 0.50</td>
+            </tr>
+            <tr>
+                <th colspan="2">Report/Interpretation</th>
+                <td colspan="2">M. <i>tuberculosis </i>infection not likely</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content2" class="uk-table tab-content">
             <tbody>
-                <tr>
-                    <th>Nil (IU/ml)</th>
-                    <td> &lt; 8.0</td>
-                    <td>&gt; 8.0</td>
-                </tr>
-                <tr>
-                    <th class="uk-text-nowrap">TB1 minus Nil (IU/ml)</th>
-                    <td>< 0.35 or > 0.35 and < 25% of Nil</td>
-                    <td>Any</td>
-                </tr>
-                <tr>
-                    <th class="uk-text-nowrap">TB2 minus Nil (IU/ml)</th>
-                    <td>< 0.35 or > 0.35 and < 25% of Nil</td>
-                    <td>Any</td>
-                </tr>
-                <tr>
-                    <th>Mitogen minus Nil</th>
-                    <td> &lt; 0.50</td>
-                    <td>Any</td>
-                </tr>
-                <tr>
-                    <th>Report/Interpretation</th>
-                    <td colspan="2">Likelihood of M. <i>tuberculosis </i>infection cannot be determined</td>
-                </tr>
+            <tr>
+                <th>Nil (IU/ml)</th>
+                <td> &lt; 8.0</td>
+                <td>> 8.0</td>
+            </tr>
+            <tr>
+                <th class="uk-text-nowrap">TB1 minus Nil (IU/ml)</th>
+                <td>< 0.35 or > 0.35 and < 25% of Nil</td>
+                <td>Any</td>
+            </tr>
+            <tr>
+                <th class="uk-text-nowrap">TB2 minus Nil (IU/ml)</th>
+                <td>< 0.35 or > 0.35 and < 25% of Nil</td>
+                <td>Any</td>
+            </tr>
+            <tr>
+                <th>Mitogen minus Nil</th>
+                <td> &lt; 0.50</td>
+                <td>Any</td>
+            </tr>
+            <tr>
+                <th>Report/Interpretation</th>
+                <td colspan="2">Likelihood of M. <i>tuberculosis </i>infection cannot be determined</td>
+            </tr>
             </tbody>
         </table>
     </div>

--- a/app/src/main/assets/pages/table_2_interpretation_criteria_for_the_t_spot_tb_test.html
+++ b/app/src/main/assets/pages/table_2_interpretation_criteria_for_the_t_spot_tb_test.html
@@ -18,7 +18,7 @@
     <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="2_diagnostic_tests_for_latent_tb_infection_(ltbi)__e__interferon_y_release_assays_(igras).html#table2"> Interferon-y Release Assays (IGRAs) </a></p>
     <p class="last-updated"><i>Last Updated October 2025</i></p>
     <hr>
-     <div class="uk-overflow-auto" id="table_2_interpretation_criteria_for_the_t_spot_tb_test">
+    <div class="uk-overflow-auto" id="table_2_interpretation_criteria_for_the_t_spot_tb_test">
         <div class="uk-tabs-container">
             <ul class="tabs">
                 <li><button class="tab active-tab" onclick="switchTab(0, event)">Positive</button></li>
@@ -30,72 +30,72 @@
 
         <table id="option-content0" class="uk-table tab-content option-content active-option">
             <tbody>
-                <tr>
-                    <th colspan="1">Nil*</th>
-                    <td colspan="1">&le; 10 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">TB Response&dagger;</th>
-                    <td colspan="1">&ge; 8 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">Mitogen&sect;</th>
-                    <td colspan="1">Any</td>
-                </tr>
+            <tr>
+                <th colspan="1">Nil*</th>
+                <td colspan="1">&le; 10 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">TB Response†</th>
+                <td colspan="1">&ge; 8 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">Mitogen&sect;</th>
+                <td colspan="1">Any</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="option-content1" class="uk-table tab-content option-content">
             <tbody>
-                <tr>
-                    <th colspan="1">Nil*</th>
-                    <td colspan="1">&lt; 10 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">TB Response&dagger;</th>
-                    <td colspan="1">5, 6, or 7 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">Mitogen&sect;</th>
-                    <td colspan="1">Any</td>
-                </tr>
+            <tr>
+                <th colspan="1">Nil*</th>
+                <td colspan="1">&lt; 10 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">TB Response†</th>
+                <td colspan="1">5, 6, or 7 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">Mitogen&sect;</th>
+                <td colspan="1">Any</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="option-content2" class="uk-table tab-content option-content">
             <tbody>
-                <tr>
-                    <th colspan="1">Nil*</th>
-                    <td colspan="1">&le; 10 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">TB Response&dagger;</th>
-                    <td colspan="1">&gt; 20 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">Mitogen&sect;</th>
-                    <td colspan="1">&gt; 20 spots</td>
-                </tr>
+            <tr>
+                <th colspan="1">Nil*</th>
+                <td colspan="1">&le; 10 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">TB Response†</th>
+                <td colspan="1">> 20 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">Mitogen&sect;</th>
+                <td colspan="1">> 20 spots</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="option-content3" class="uk-table tab-content option-content">
             <tbody>
-                <tr>
-                    <th colspan="1">Nil*</th>
-                    <td colspan="1">&le; 10 spots</td>
-                    <td colspan="1">&le; 10 spots</td>
-                </tr>
-                <tr>
-                    <th colspan="1">TB Response&dagger;</th>
-                    <td colspan="1">Any</td>
-                    <td colspan="1">< 5 spots</td>
-                </tr>
-                <tr>
-                    <th class="uk-table-small" colspan="1">Mitogen&sect;</th>
-                    <td colspan="1">Any</td>
-                    <td colspan="1">< 20 spots</td>
-                </tr>
+            <tr>
+                <th colspan="1">Nil*</th>
+                <td colspan="1">&le; 10 spots</td>
+                <td colspan="1">&le; 10 spots</td>
+            </tr>
+            <tr>
+                <th colspan="1">TB Response†</th>
+                <td colspan="1">Any</td>
+                <td colspan="1">< 5 spots</td>
+            </tr>
+            <tr>
+                <th class="uk-table-small" colspan="1">Mitogen&sect;</th>
+                <td colspan="1">Any</td>
+                <td colspan="1">< 20 spots</td>
+            </tr>
             </tbody>
         </table>
     </div>

--- a/app/src/main/assets/pages/table_3_high_prevalence_and_high_risk_groups.html
+++ b/app/src/main/assets/pages/table_3_high_prevalence_and_high_risk_groups.html
@@ -18,16 +18,16 @@
     <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="2_diagnostic_tests_for_latent_tb_infection_(ltbi)__f__targeted_testing_and_diagnostic_tests_for_ltbi.html#table3"> Targeted Testing and Diagnostic Tests </a></p>
     <p class="last-updated"><i>Last Updated October 2025</i></p>
     <hr>
-     <div class="uk-overflow-auto" id="table_3_high_prevalence_and_high_risk_groups">
+    <div class="uk-overflow-auto" id="table_3_high_prevalence_and_high_risk_groups">
         <table class="uk-table uk-table-small uk-table-divider">
             <tbody>
             <tr>
-                <th>Groups With a High Prevalence of Latent TB Infection&nbsp;</th>
+                <th>Groups With a High Prevalence of Latent TB Infection </th>
                 <th>Groups With a High Risk of Progression to Active TB Disease if <u>Infected</u> with M. tuberculosis</th>
             </tr>
             <tr>
                 <td>Persons born in countries with high rates of TB</td>
-                <td>Persons living with HIV Persons who are close contacts of persons with infectious active TB&nbsp;
+                <td>Persons living with HIV Persons who are close contacts of persons with infectious active TB
                 </td>
             </tr>
             <tr>
@@ -37,7 +37,7 @@
             <tr>
                 <td>Persons who live or spend time in certain facilities (e.g., nursing homes, correctional
                     institutions,
-                    homeless shelters, drug treatment centers)&nbsp;
+                    homeless shelters, drug treatment centers)
                 </td>
                 <td>Persons with recent infection with M. tuberculosis (e.g., have had a diagnostic test result for LTBI
                     convert to positive in the past 1-2 years) Persons who have chest radiographs suggestive of old TB
@@ -50,7 +50,7 @@
             <tr>
                 <td colspan="2">*Diabetes mellitus, silicosis, prolonged therapy with corticosteroids, immunosuppressive
                     therapy particularly TNF-&alpha; blockers, leukemia, Hodgkin&rsquo;s disease, head and neck cancers,
-                    severe kidney disease, certain intestinal conditions, malnutrition&nbsp;
+                    severe kidney disease, certain intestinal conditions, malnutrition
                 </td>
             </tr>
             </tbody>

--- a/app/src/main/assets/pages/table_4_recommendations_for_regimens_to_treat_latent_tuberculosis_infection.html
+++ b/app/src/main/assets/pages/table_4_recommendations_for_regimens_to_treat_latent_tuberculosis_infection.html
@@ -18,7 +18,7 @@
     <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="3_treatment_of_latent_tb_infection_(ltbi)__a__treatment_regimens.html#table4"> Treatment Regimens for LTBI </a></p>
     <p class="last-updated"><i>Last Updated October 2025</i></p>
     <hr>
-     <div class="uk-overflow-auto" id="table_4_recommendations_for_regimens_to_treat_latent_tuberculosis_infection">
+    <div class="uk-overflow-auto" id="table_4_recommendations_for_regimens_to_treat_latent_tuberculosis_infection">
         <div class="uk-tabs-container">
             <ul class="tabs">
                 <li><button class="tab active-tab" onclick="switchTab(0, event)">Preferred</button></li>
@@ -28,51 +28,51 @@
 
         <table id="tab-content0" class="uk-table uk-table-small uk-table-divider tab-content active-tab">
             <tbody>
-                <tr>
-                    <th>Regimes</th>
-                    <td>3 months isoniazid plus rifapentine given once weekly</td>
-                    <td>4 months rifampin given daily</td>
-                    <td>3 months isoniazid plus rifampin given daily</td>
-                </tr>
-                <tr>
-                    <th>Recommendation (Strong or Conditional)</th>
-                    <td>Strong</td>
-                    <td>Strong</td>
-                    <td>Conditional</td>
-                </tr>
-                <tr>
-                    <th>Evidence (High, Moderate, Low, or Very Low)</th>
-                    <td>Moderate</td>
-                    <td>Moderate (HIV negative) &dagger; </td>
-                    <td>Very low (HIV negative) &dagger; </td>
-                </tr>
+            <tr>
+                <th>Regimes</th>
+                <td>3 months isoniazid plus rifapentine given once weekly</td>
+                <td>4 months rifampin given daily</td>
+                <td>3 months isoniazid plus rifampin given daily</td>
+            </tr>
+            <tr>
+                <th>Recommendation (Strong or Conditional)</th>
+                <td>Strong</td>
+                <td>Strong</td>
+                <td>Conditional</td>
+            </tr>
+            <tr>
+                <th>Evidence (High, Moderate, Low, or Very Low)</th>
+                <td>Moderate</td>
+                <td>Moderate (HIV negative) † </td>
+                <td>Very low (HIV negative) † </td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content1" class="uk-table uk-table-small uk-table-divider tab-content">
             <tbody>
-                <tr>
-                    <th>Regimes</th>
-                    <td>6 months isoniazid given daily</td>
-                    <td>9 months isoniazid given daily</td>
-                    <td>3 months isoniazid plus rifampin given daily</td>
-                </tr>
-                <tr>
-                    <th>Recommendation (Strong or Conditional)</th>
-                    <td>Strong &sect;</td>
-                    <td>Conditional</td>
-                    <td>Conditional</td>
-                </tr>
-                <tr>
-                    <th>Evidence (High, Moderate, Low, or Very Low)</th>
-                    <td>Moderate (HIV negative)</td>
-                    <td>Moderate (if living with HIV)</td>
-                    <td>Moderate</td>
-                </tr>
+            <tr>
+                <th>Regimes</th>
+                <td>6 months isoniazid given daily</td>
+                <td>9 months isoniazid given daily</td>
+                <td>3 months isoniazid plus rifampin given daily</td>
+            </tr>
+            <tr>
+                <th>Recommendation (Strong or Conditional)</th>
+                <td>Strong &sect;</td>
+                <td>Conditional</td>
+                <td>Conditional</td>
+            </tr>
+            <tr>
+                <th>Evidence (High, Moderate, Low, or Very Low)</th>
+                <td>Moderate (HIV negative)</td>
+                <td>Moderate (if living with HIV)</td>
+                <td>Moderate</td>
+            </tr>
             </tbody>
         </table>
     </div>
-    
+
     <p>Abbreviation: HIV = human immunodeficiency virus <br>
         <i>* Preferred: excellent tolerability and efficacy, shorter treatment duration,
             higher completion rates than longer regimens, and therefore higher

--- a/app/src/main/assets/pages/table_5_dosages_for_recommended_lbti_treatment_regimens.html
+++ b/app/src/main/assets/pages/table_5_dosages_for_recommended_lbti_treatment_regimens.html
@@ -18,135 +18,135 @@
     <p> <span class="view-in-chapter-highlight"> View in chapter → <span> <a href="3_treatment_of_latent_tb_infection_(ltbi)__a__treatment_regimens.html#table5"> Treatment Regimens for LTBI </a></p>
     <p class="last-updated"><i>Last Updated October 2025</i></p>
     <hr>
-     <div class="uk-overflow-auto" id="table_5_dosages_for_recommended_lbti_treatment_regimens">
+    <div class="uk-overflow-auto" id="table_5_dosages_for_recommended_lbti_treatment_regimens">
         <div class="uk-tabs-container">
             <ul class="tabs">
-                <li><button class="tab active-tab" onclick="switchTab(0, event)">Isoniazid* and rifapentine&dagger;</button></li>
-                <li><button class="tab" onclick="switchTab(1, event)">Rifampin&para;</button></li>
-                <li><button class="tab" onclick="switchTab(2, event)">Isoniazid* and rifampin&para;</button></li>
+                <li><button class="tab active-tab" onclick="switchTab(0, event)">Isoniazid* and rifapentine†</button></li>
+                <li><button class="tab" onclick="switchTab(1, event)">Rifampin¶</button></li>
+                <li><button class="tab" onclick="switchTab(2, event)">Isoniazid* and rifampin¶</button></li>
                 <li><button class="tab" onclick="switchTab(3, event)">Isoniazid*</button></li>
             </ul>
         </div>
 
         <table id="tab-content0" class="uk-table uk-table-small tab-content active-tab">
             <tbody>
-                <tr>
-                    <th>Duration</th>
-                    <td>3 months</td>
-                </tr>
-                <tr>
-                    <th>Dosage And Age Group</th>
-                    <td>
-                        <strong class="highlight">Adults and children aged &gt; 12 yrs</strong><br>
-                        <strong>Isoniazid:</strong><br>
-                        15 mg/kg rounded up to the nearest 50 or 100 mg; 900 mg maximum<br>
-                        <strong>Rifapentine:</strong><br>
-                        10 - 14.0 kg, 300 mg<br>
-                        14.1 - 25.0 kg, 450 mg<br>
-                        25. 1 - 32.0 kg, 600 mg<br>
-                        32.1 - 49.9 kg, 750 mg<br>
-                        &gt; 50.0 kg, 900 mg maximum&nbsp;<br>
-                        <br>
-                        <strong class="highlight">Children aged 2 - 11 yrs</strong><br>
-                        <strong>Isoniazid*</strong>: <br> 25 mg/kg; 900 mg maximum<br>
-                        <strong>Rifapentine&dagger;</strong>: <br>
-                        see above&nbsp;<br>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Frequency</th>
-                    <td>Once weekly</td>
-                </tr>
-                <tr>
-                    <th>Total doses</th>
-                    <td>12</td>
-                </tr>
+            <tr>
+                <th>Duration</th>
+                <td>3 months</td>
+            </tr>
+            <tr>
+                <th>Dosage And Age Group</th>
+                <td>
+                    <strong class="highlight">Adults and children aged > 12 yrs</strong><br>
+                    <strong>Isoniazid:</strong><br>
+                    15 mg/kg rounded up to the nearest 50 or 100 mg; 900 mg maximum<br>
+                    <strong>Rifapentine:</strong><br>
+                    10 - 14.0 kg, 300 mg<br>
+                    14.1 - 25.0 kg, 450 mg<br>
+                    25. 1 - 32.0 kg, 600 mg<br>
+                    32.1 - 49.9 kg, 750 mg<br>
+                    > 50.0 kg, 900 mg maximum <br>
+                    <br>
+                    <strong class="highlight">Children aged 2 - 11 yrs</strong><br>
+                    <strong>Isoniazid*</strong>: <br> 25 mg/kg; 900 mg maximum<br>
+                    <strong>Rifapentine†</strong>: <br>
+                    see above <br>
+                </td>
+            </tr>
+            <tr>
+                <th>Frequency</th>
+                <td>Once weekly</td>
+            </tr>
+            <tr>
+                <th>Total doses</th>
+                <td>12</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content1" class="uk-table uk-table-small tab-content">
             <tbody>
-                <tr>
-                    <th>Duration</th>
-                    <td>4 months</td>
-                </tr>
-                <tr>
-                    <th>Dosage And Age Group</th>
-                    <td>
-                        <strong>Adults</strong>: 10 mg/kg<br>
-                        <strong>Children</strong>: 15 - 20 mg/kg**<br>
-                        <strong>Maximum dose</strong>: 600 mg<br>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Frequency</th>
-                    <td>Daily</td>
-                </tr>
-                <tr>
-                    <th>Total doses</th>
-                    <td>120</td>
-                </tr>
+            <tr>
+                <th>Duration</th>
+                <td>4 months</td>
+            </tr>
+            <tr>
+                <th>Dosage And Age Group</th>
+                <td>
+                    <strong>Adults</strong>: 10 mg/kg<br>
+                    <strong>Children</strong>: 15 - 20 mg/kg**<br>
+                    <strong>Maximum dose</strong>: 600 mg<br>
+                </td>
+            </tr>
+            <tr>
+                <th>Frequency</th>
+                <td>Daily</td>
+            </tr>
+            <tr>
+                <th>Total doses</th>
+                <td>120</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content2" class="uk-table uk-table-small tab-content">
             <tbody>
-                <tr>
-                    <th>Duration</th>
-                    <td>3 months</td>
-                </tr>
-                <tr>
-                    <th>Dosage And Age Group</th>
-                    <td>
-                        <strong class="highlight">Adults </strong> <br>
-                        <strong>Isoniazid*</strong>: <br> 5 mg/kg; 300 mg maximum <br>
-                        <strong>Rifampin&para;</strong>: <br> 10 mg/kg; 600 mg maximum <br><br>
-                        <strong class="highlight">Children</strong>: <br>
-                        <strong>Isoniazid*</strong>: <br> 10 - 20 mg/kg&dagger;&dagger; ; 300 mg maximum <br>
-                        <strong>Rifampin&para;</strong>: <br> 15 - 20 mg/kg; 600 mg maximum <br>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Frequency</th>
-                    <td>Daily</td>
-                </tr>
-                <tr>
-                    <th>Total doses</th>
-                    <td>90</td>
-                </tr>
+            <tr>
+                <th>Duration</th>
+                <td>3 months</td>
+            </tr>
+            <tr>
+                <th>Dosage And Age Group</th>
+                <td>
+                    <strong class="highlight">Adults </strong> <br>
+                    <strong>Isoniazid*</strong>: <br> 5 mg/kg; 300 mg maximum <br>
+                    <strong>Rifampin¶</strong>: <br> 10 mg/kg; 600 mg maximum <br><br>
+                    <strong class="highlight">Children</strong>: <br>
+                    <strong>Isoniazid*</strong>: <br> 10 - 20 mg/kg†† ; 300 mg maximum <br>
+                    <strong>Rifampin¶</strong>: <br> 15 - 20 mg/kg; 600 mg maximum <br>
+                </td>
+            </tr>
+            <tr>
+                <th>Frequency</th>
+                <td>Daily</td>
+            </tr>
+            <tr>
+                <th>Total doses</th>
+                <td>90</td>
+            </tr>
             </tbody>
         </table>
 
         <table id="tab-content3" class="uk-table uk-table-small tab-content">
             <tbody>
-                <tr>
-                    <th>Duration</th>
-                    <td>9 months</td>
-                    <td>6 months</td>
-                </tr>
-                <tr>
-                    <th>Dosage And Age Group</th>
-                    <td>
-                        <strong>Adults</strong>: <br> 5 mg/kg <br>
-                        <strong>Children</strong>: <br> 10 - 20 mg/kg&dagger;&dagger; <br>
-                        <strong>Maximum dose</strong>: <br> 300 mg <br>
-                    </td>
-                    <td>
-                        <strong>Adults</strong>: <br> 5 mg/kg <br>
-                        <strong>Children</strong>: <br> 10 - 20 mg/kg&dagger;&dagger; <br>
-                        <strong>Maximum dose</strong>: <br> 300 mg <br>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Frequency</th>
-                    <td>Daily</td>
-                    <td>Daily</td>
-                </tr>
-                <tr>
-                    <th>Total doses</th>
-                    <td>270</td>
-                    <td>180</td>
-                </tr>
+            <tr>
+                <th>Duration</th>
+                <td>9 months</td>
+                <td>6 months</td>
+            </tr>
+            <tr>
+                <th>Dosage And Age Group</th>
+                <td>
+                    <strong>Adults</strong>: <br> 5 mg/kg <br>
+                    <strong>Children</strong>: <br> 10 - 20 mg/kg†† <br>
+                    <strong>Maximum dose</strong>: <br> 300 mg <br>
+                </td>
+                <td>
+                    <strong>Adults</strong>: <br> 5 mg/kg <br>
+                    <strong>Children</strong>: <br> 10 - 20 mg/kg†† <br>
+                    <strong>Maximum dose</strong>: <br> 300 mg <br>
+                </td>
+            </tr>
+            <tr>
+                <th>Frequency</th>
+                <td>Daily</td>
+                <td>Daily</td>
+            </tr>
+            <tr>
+                <th>Total doses</th>
+                <td>270</td>
+                <td>180</td>
+            </tr>
             </tbody>
         </table>
     </div>
@@ -156,7 +156,7 @@
     </p>
 </div>
 </body>
-       
+
 <script src="../assets/uikit.js" type="text/javascript"></script>
 <script src="../assets/uikit-icons.js" type="text/javascript"></script>
 <script src="../assets/main.js" type="text/javascript"></script>

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/MainActivity.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/MainActivity.kt
@@ -130,6 +130,43 @@ class MainActivity : AppCompatActivity(), ActionBarController {
         }
 
         binding.bottomNavigationView.setupWithNavController(navController)
+
+        // Intercept bottom navigation selections so that selecting any bottom-nav
+        // item always navigates to that destination (popping back to it if it's
+        // already in the back stack). This guarantees the Home button always
+        // leads to the mainFragment regardless of intermediate navigation.
+        binding.bottomNavigationView.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.mainFragment -> {
+                    // If mainFragment is already in the back stack, pop back to it.
+                    // Otherwise navigate to it.
+                    val popped = navController.popBackStack(R.id.mainFragment, false)
+                    if (!popped) navController.navigate(R.id.mainFragment)
+                    true
+                }
+                R.id.globalSearchFragment -> {
+                    val popped = navController.popBackStack(R.id.globalSearchFragment, false)
+                    if (!popped) navController.navigate(R.id.globalSearchFragment)
+                    true
+                }
+                R.id.settingsFragment -> {
+                    val popped = navController.popBackStack(R.id.settingsFragment, false)
+                    if (!popped) navController.navigate(R.id.settingsFragment)
+                    true
+                }
+                else -> false
+            }
+        }
+
+        // Keep a reselection handler for when the user taps the already-selected
+        // item (e.g., scroll-to-top or ensure we are on the root of that tab).
+        binding.bottomNavigationView.setOnItemReselectedListener { item ->
+            when (item.itemId) {
+                R.id.mainFragment -> navController.popBackStack(R.id.mainFragment, false)
+                R.id.globalSearchFragment -> navController.popBackStack(R.id.globalSearchFragment, false)
+                R.id.settingsFragment -> navController.popBackStack(R.id.settingsFragment, false)
+            }
+        }
         // Removed this line to the prevent default back arrow:
         // setupActionBarWithNavController(navController, AppBarConfiguration(navController.graph))
     }

--- a/app/src/main/res/layout/fragment_saved.xml
+++ b/app/src/main/res/layout/fragment_saved.xml
@@ -13,6 +13,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:paddingTop="42dp"
+        android:paddingBottom="@dimen/bottom_nav_height"
         android:clipToPadding="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,4 +3,5 @@
     <dimen name="tab_padding_small">4dp</dimen>
     <dimen name="tab_padding_medium">8dp</dimen>
     <dimen name="tab_padding_large">12dp</dimen>
+    <dimen name="bottom_nav_height">72dp</dimen>
 </resources>


### PR DESCRIPTION

### Summary

This PR fixes two related issues on the Saved (My Bookmarks) screen:
The bottom navigation items (Home/Search/Settings) were not receiving taps because the fragment content overlapped the BottomNavigationView.
The Home button behaviour was inconsistent: after visiting Saved and then switching to Search or Settings, tapping Home could return the user back to Saved instead of always taking them to Home.

### What was causing the bug

Touch interception: fragment_saved's RecyclerView was constrained to the parent bottom edge and could overlap the BottomNavigationView; even when the nav was visible on top, the RecyclerView continued to intercept touch events so taps on the bottom nav did nothing in some states.

Navigation/back-stack semantics: SavedFragment is not a bottom-nav destination. After navigating from mainFragment → savedFragment, the BottomNavigationView still showed the Home item as selected. The Navigation component (via setupWithNavController) will ignore reselection by default. Because of the back stack state, tapping Home did not always navigate to the true mainFragment—it sometimes left savedFragment on top, producing the incorrect behaviour.

### Solution

Prevent touch interception by leaving space at the bottom of the content: add bottom padding to the RecyclerView in fragment_saved.xml and use a dimen resource for the nav height. clipToPadding="false" allows the RecyclerView to scroll under that padding while keeping the bottom touch area free.
Make bottom-nav selection explicit: intercept bottom nav item selections and either pop back to the matching destination if it exists in the back stack or navigate to it otherwise. Also keep a reselection handler for consistent behavior on tapping an already-selected tab. This ensures Home always navigates to mainFragment.

### Files changed

**fragment_saved.xml**
Added: android:paddingBottom="@dimen/bottom_nav_height" on bookmarks_recycler_view (keeps bottom nav clickable)
dimens.xml
Added: <dimen name="bottom_nav_height">72dp</dimen> (adjustable)

**MainActivity.kt**
Added a custom setOnItemSelectedListener to the BottomNavigationView that:
tries navController.popBackStack(<destinationId>, false) and navigates if pop failed
guarantees selecting Home always ends up on mainFragment
Added a setOnItemReselectedListener to handle reselection (pop back to root of that tab)
```kotlin
 // Intercept bottom navigation selections so that selecting any bottom-nav
        // item always navigates to that destination (popping back to it if it's
        // already in the back stack). This guarantees the Home button always
        // leads to the mainFragment regardless of intermediate navigation.
        binding.bottomNavigationView.setOnItemSelectedListener { item ->
            when (item.itemId) {
                R.id.mainFragment -> {
                    // If mainFragment is already in the back stack, pop back to it.
                    // Otherwise navigate to it.
                    val popped = navController.popBackStack(R.id.mainFragment, false)
                    if (!popped) navController.navigate(R.id.mainFragment)
                    true
                }
                R.id.globalSearchFragment -> {
                    val popped = navController.popBackStack(R.id.globalSearchFragment, false)
                    if (!popped) navController.navigate(R.id.globalSearchFragment)
                    true
                }
                R.id.settingsFragment -> {
                    val popped = navController.popBackStack(R.id.settingsFragment, false)
                    if (!popped) navController.navigate(R.id.settingsFragment)
                    true
                }
                else -> false
            }
        }

```

**Bottom padding in fragment_saved.xml:**
bookmarks RecyclerView:
android:paddingBottom="@dimen/bottom_nav_height"
android:clipToPadding="false" (already present)
MainActivity navigation changes:
binding.bottomNavigationView.setOnItemSelectedListener { ... } — ensures deterministic navigation behavior
binding.bottomNavigationView.setOnItemReselectedListener { ... } — preserves reselection semantics (pop to root)

**Testing / Verification**

- From the Home (main) screen:

- Tap MY Bookmarks  — confirm the My Bookmarks screen opens.

- Tap Home — should return to Home (mainFragment).

- From Home, open Saved again, then:

- Tap Search — confirm it goes to Search.

- Tap Settings — confirm it goes to Settings.

- Tap Home — must always go to Home (mainFragment) (this was the incorrect behavior before).

- On Saved screen, verify bottom nav buttons are responsive (touches register immediately).

- Verify RecyclerView scroll still works and content isn't covered visually (padding is only space — RecyclerView can scroll under the padding).