### PR TITLE
Fix blank “Chapters/Tables/WebView” screens after returning Home (first install/update)

### DIFF
--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/Database.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/Database.kt
@@ -1,10 +1,9 @@
 package org.apphatchery.gatbreferenceguide.db
 
+import android.util.Log
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import androidx.room.withTransaction
 import org.apphatchery.gatbreferenceguide.db.dao.*
 import org.apphatchery.gatbreferenceguide.db.entities.*
 
@@ -32,16 +31,14 @@ abstract class Database : RoomDatabase() {
     abstract fun recentDao(): RecentDao
     abstract fun contactDao(): ContactDao
 
-  @OptIn(DelicateCoroutinesApi::class)
-  fun purgeData(){
-      GlobalScope.launch {
+  suspend fun purgeData() {
+      Log.w("DB_PURGE", "purgeData() called", Throwable("purgeData stack"))
+      withTransaction {
           chapterDao().deleteAll()
           chartDao().deleteAll()
           subChapterDao().deleteAll()
           htmlInfoDao().deleteAll()
           globalSearchDao().deleteAll()
       }
-
-
-    }
+  }
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/ChapterDao.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/ChapterDao.kt
@@ -30,4 +30,7 @@ interface ChapterDao {
 
     @Query("DELETE FROM ChapterEntity")
     suspend fun deleteAll()
+
+    @Query("SELECT COUNT(*) FROM ChapterEntity")
+    suspend fun count(): Int
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/ChartDao.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/ChartDao.kt
@@ -34,4 +34,7 @@ interface ChartDao {
     @Query("DELETE FROM ChartEntity")
     suspend fun deleteAll()
 
+    @Query("SELECT COUNT(*) FROM ChartEntity")
+    suspend fun count(): Int
+
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/GlobalSearchDao.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/GlobalSearchDao.kt
@@ -33,4 +33,7 @@ interface GlobalSearchDao {
     @Query("DELETE FROM GlobalSearchEntity")
     suspend fun deleteAll()
 
+    @Query("SELECT COUNT(*) FROM GlobalSearchEntity")
+    suspend fun count(): Int
+
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/HtmlInfoDao.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/HtmlInfoDao.kt
@@ -22,4 +22,7 @@ interface HtmlInfoDao {
     @Query("DELETE FROM HtmlInfoEntity")
     suspend fun deleteAll()
 
+    @Query("SELECT COUNT(*) FROM HtmlInfoEntity")
+    suspend fun count(): Int
+
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/SubChapterDao.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/dao/SubChapterDao.kt
@@ -56,4 +56,7 @@ interface SubChapterDao {
             keyword
         )
     }
+
+    @Query("SELECT COUNT(*) FROM SubChapterEntity")
+    suspend fun count(): Int
 }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/db/repositories/Repository.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/db/repositories/Repository.kt
@@ -17,7 +17,7 @@ class Repository @Inject constructor(
     private val subChapterDao = db.subChapterDao()
     private val chartDao = db.chartDao()
 
-    fun purgeData(){
+    suspend fun purgeData() {
         db.purgeData()
     }
 

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/ChapterFragment.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/ChapterFragment.kt
@@ -31,6 +31,7 @@ class ChapterFragment : BaseFragment(R.layout.fragment_with_recyclerview) {
     private lateinit var bind: FragmentWithRecyclerviewBinding
     private lateinit var faChapterAdapter: FAChapterAdapter
     private val viewModel: FAChapterViewModel by viewModels()
+    private var hadData = false
 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -39,6 +40,10 @@ class ChapterFragment : BaseFragment(R.layout.fragment_with_recyclerview) {
 
         faChapterAdapter = FAChapterAdapter().also {
             viewModel.getChapterEntity.observe(viewLifecycleOwner) { data ->
+                if (data.isNotEmpty()) hadData = true
+                if (hadData && data.isEmpty()) {
+                    Log.w("ChapterFragment", "Chapter list became empty after having data")
+                }
                 bind.apply {
 //                    data.size.searchNotFound(recyclerview, searchNotFound)
                     it.submitList(data)

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/ChartFragment.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/ChartFragment.kt
@@ -23,12 +23,17 @@ class ChartFragment : BaseFragment(R.layout.fragment_with_recyclerview) {
     private lateinit var bind: FragmentWithRecyclerviewBinding
     private lateinit var faChartAdapter: FAChartAdapter
     private val viewModel: FAChartViewModel by viewModels()
+    private var hadData = false
 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         bind = FragmentWithRecyclerviewBinding.bind(view)
         faChartAdapter = FAChartAdapter().also { faChartAdapter ->
             viewModel.getChart.observe(viewLifecycleOwner) {
+                if (it.isNotEmpty()) hadData = true
+                if (hadData && it.isEmpty()) {
+                    Log.w("ChartFragment", "Chart list became empty after having data")
+                }
                 faChartAdapter.submitList(it)
             }
 

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/MainFragment.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/MainFragment.kt
@@ -8,7 +8,6 @@ import android.widget.ProgressBar
 import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.asLiveData
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
@@ -28,6 +27,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.apphatchery.gatbreferenceguide.R
 import org.apphatchery.gatbreferenceguide.databinding.FragmentMainBinding
@@ -96,9 +96,11 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
             // Web content is stored under cacheDir; if user cleared cache it may be missing.
             // Rebuild it even when BUILD_VERSION has not changed.
             withContext(Dispatchers.IO) {
-                val ctx = requireContext().applicationContext
-                if (!ctx.isGuideWebContentPresent()) {
-                    ctx.replaceBundledGuideWebContent()
+                AppInitLock.mutex.withLock {
+                    val ctx = requireContext().applicationContext
+                    if (!ctx.isGuideWebContentPresent()) {
+                        ctx.replaceBundledGuideWebContent()
+                    }
                 }
             }
 
@@ -117,6 +119,12 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
 
             first6ChapterAdapter = FAMainFirst6ChapterAdapter().also { adapter ->
                 viewModel.getChapter.observe(viewLifecycleOwner) {
+                    if (it.size < 15) {
+                        // Data not ready yet; keep loading state.
+                        fragmentMainBinding.progressBar.isVisible = true
+                        fragmentMainBinding.group.isVisible = false
+                        return@observe
+                    }
                     with(predefinedChapterList) {
                         clear()
                         add(it[0].copy(chapterTitle = "All Chapters>"))
@@ -148,6 +156,12 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
 
             first6ChartAdapter = FAMainFirst6ChartAdapter().also { adapter ->
                 viewModel.getChart.observe(viewLifecycleOwner) { data ->
+                    if (data.size < 18) {
+                        // Data not ready yet; keep loading state.
+                        fragmentMainBinding.progressBar.isVisible = true
+                        fragmentMainBinding.group.isVisible = false
+                        return@observe
+                    }
                     with(predefinedChartList) {
                         clear()
                         add(data[0].copy(chartEntity = data[0].chartEntity.copy(chartTitle = "All Tables>")))
@@ -194,12 +208,11 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 
         fragmentMainBinding = FragmentMainBinding.bind(view)
-        userPrefs.getBuildVersion.asLiveData().observe(viewLifecycleOwner) {
-            if (it != BUILD_VERSION)
-            {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val version = userPrefs.getBuildVersion.first()
+            if (version != BUILD_VERSION) {
                 firstLaunch()
-            }
-            else {
+            } else {
                 init()
             }
         }
@@ -254,7 +267,6 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
         })
 
     }
-
 
 
     private fun RecyclerView.setupAdapter(
@@ -403,50 +415,40 @@ class MainFragment : BaseFragment(R.layout.fragment_main) {
         // Mark initialization as started
         isInitializing = true
         initializationComplete = false
-        
-        viewModel.purgeData()
+
         getBottomNavigationView()?.toggleVisibility(false)
         
         // Keep progress bar visible and hide content during initialization
         fragmentMainBinding.progressBar.isVisible = true
         fragmentMainBinding.group.isVisible = false
-        
-        // moved the heavy I/O operations to a background thread to prevent WebView renderer crashes
-        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-            // Fully replace cached HTML/CSS/JS/images so app updates never show mixed old/new content.
-            applicationContext.replaceBundledGuideWebContent()
 
-            // One-time background migration: update saved notes to point to renamed/merged targets.
-            // Example: notes on old tables 10/11/12 -> new table 9.
-            LegacyNotesMigrator.migrateNoteTargets(db)
-            
-            // Switch back to main thread for ui operations
-            withContext(Dispatchers.Main) {
-                dumpChartData()
+        // moved the heavy I/O operations to a background thread to prevent WebView renderer crashes
+        // Use Fragment lifecycleScope so this work isn't cancelled on navigation.
+        lifecycleScope.launch(Dispatchers.IO) {
+            AppInitLock.mutex.withLock {
+                // Fully replace cached HTML/CSS/JS/images so app updates never show mixed old/new content.
+                applicationContext.replaceBundledGuideWebContent()
+
+                // One-time background migration: update saved notes to point to renamed/merged targets.
+                // Example: notes on old tables 10/11/12 -> new table 9.
+                LegacyNotesMigrator.migrateNoteTargets(db)
+
+                // Seed DB from bundled assets (purge+insert+global search in one transaction).
+                viewModel.purgeAndSeedFromAssets(applicationContext)
+
+                // Persist version only after seeding completes.
+                userPrefs.setBuildVersion(BUILD_VERSION)
+                userPrefs.setPendoVisitorId(getVisitorId())
             }
-        }
-    }
-    viewLifecycleOwner.lifecycleScope.launchWhenStarted {
-        viewModel.taskFlowEvent.collect {
-            when (it) {
-                FAMainViewModel.Callback.InsertHTMLInfoComplete -> {
-                    viewModel.bindHtmlWithChapter()
-                }
-                FAMainViewModel.Callback.InsertGlobalSearchInfoComplete -> {
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        userPrefs.setBuildVersion(BUILD_VERSION)
-                        userPrefs.setPendoVisitorId(getVisitorId())
-                    }
-                    
-                    // Mark initialization as complete
-                    isInitializing = false
-                    initializationComplete = true
-                    
-                    // Now safe to show content and enable navigation
-                    requireActivity().getBottomNavigationView()?.isEnabled = true
-                    
-                    init()
-                }
+
+            withContext(Dispatchers.Main) {
+                // If user navigated away mid-seed, skip touching UI.
+                if (view == null) return@withContext
+
+                isInitializing = false
+                initializationComplete = true
+                requireActivity().getBottomNavigationView()?.isEnabled = true
+                init()
             }
         }
     }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/SubChapterFragment.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/fragments/SubChapterFragment.kt
@@ -39,6 +39,7 @@ class SubChapterFragment : BaseFragment(R.layout.fragment_with_recyclerview) {
     private lateinit var chapterEntity: ChapterEntity
     private val viewModel: FASubChapterViewModel by viewModels()
     private val mainViewModel: MainActivityViewModel by activityViewModels()
+    private var hadData = false
 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -49,6 +50,10 @@ class SubChapterFragment : BaseFragment(R.layout.fragment_with_recyclerview) {
 
         faSubChapterAdapter = FASubChapterAdapter()
         viewModel.getSubChapterEntity.observe(viewLifecycleOwner) {
+            if (it.isNotEmpty()) hadData = true
+            if (hadData && it.isEmpty()) {
+                Log.w("SubChapterFragment", "SubChapter list became empty after having data")
+            }
             bind.apply {
                 faSubChapterAdapter.submitList(it)
             }

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/viewmodels/FAMainViewModel.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/ui/viewmodels/FAMainViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.room.withTransaction
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -19,6 +21,11 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.apphatchery.gatbreferenceguide.db.entities.*
 import org.apphatchery.gatbreferenceguide.db.repositories.Repository
+import org.apphatchery.gatbreferenceguide.utils.EXTENSION
+import org.apphatchery.gatbreferenceguide.utils.PAGES_DIR
+import org.apphatchery.gatbreferenceguide.utils.html2text
+import org.apphatchery.gatbreferenceguide.utils.readJsonFromAssetToString
+import org.apphatchery.gatbreferenceguide.utils.removeSlash
 import org.jsoup.Jsoup
 import java.io.File
 import java.io.FileOutputStream
@@ -45,8 +52,131 @@ class FAMainViewModel @Inject constructor(
     private val taskFlowChannel = Channel<Callback>()
     val taskFlowEvent = taskFlowChannel.receiveAsFlow()
 
-    fun purgeData(){
+    suspend fun purgeData() {
         repo.purgeData()
+    }
+
+    /**
+     * One-shot initialization for first install / app update.
+     *
+     * This avoids fragment-lifecycle-dependent seeding chains (LiveData observers) that can be
+     * interrupted when users navigate quickly.
+     */
+    suspend fun purgeAndSeedFromAssets(context: Context) {
+        val initId = System.currentTimeMillis()
+        val t0 = System.nanoTime()
+        Log.i("INIT_SEED", "[$initId] start purge+seed from assets")
+        val charts: List<ChartEntity> = parseAssetJson(context, "chart.json")
+        val chapters: List<ChapterEntity> = parseAssetJson(context, "chapter.json")
+        val subChapters: List<SubChapterEntity> = parseAssetJson(context, "subchapter.json")
+        val htmlInfo: List<HtmlInfoEntity> = extractHtmlInfoFromAssets(context)
+
+        repo.db.withTransaction {
+            // Purge + seed must be a single atomic transaction.
+            // Database.purgeData() not called here because it starts its own transaction.
+            repo.db.chapterDao().deleteAll()
+            repo.db.chartDao().deleteAll()
+            repo.db.subChapterDao().deleteAll()
+            repo.db.htmlInfoDao().deleteAll()
+            repo.db.globalSearchDao().deleteAll()
+
+            repo.db.chapterDao().insert(chapters)
+            repo.db.subChapterDao().insert(subChapters)
+            repo.db.chartDao().insert(charts)
+            repo.db.htmlInfoDao().insert(htmlInfo)
+
+            rebuildGlobalSearchLocked()
+        }
+
+        val chapterCount = repo.db.chapterDao().count()
+        val subChapterCount = repo.db.subChapterDao().count()
+        val chartCount = repo.db.chartDao().count()
+        val htmlCount = repo.db.htmlInfoDao().count()
+        val globalSearchCount = repo.db.globalSearchDao().count()
+        val ms = (System.nanoTime() - t0) / 1_000_000
+        Log.i(
+            "INIT_SEED",
+            "[$initId] done in ${ms}ms counts: chapters=$chapterCount subChapters=$subChapterCount charts=$chartCount html=$htmlCount globalSearch=$globalSearchCount"
+        )
+    }
+
+    private inline fun <reified T> parseAssetJson(context: Context, fileName: String): List<T> {
+        val json = context.readJsonFromAssetToString(fileName)
+            ?: throw IllegalStateException("Missing asset json: $fileName")
+        val type = object : TypeToken<List<T>>() {}.type
+        return Gson().fromJson<List<T>>(json, type)
+            ?: throw IllegalStateException("Failed to parse asset json: $fileName")
+    }
+
+    private fun extractHtmlInfoFromAssets(context: Context): List<HtmlInfoEntity> {
+        val results = ArrayList<HtmlInfoEntity>()
+        context.assets.list(PAGES_DIR.removeSlash())?.forEach { entry ->
+            val file = PAGES_DIR + entry
+            var fileName = file.replace(EXTENSION, "")
+            fileName = fileName.replace(PAGES_DIR, "")
+            results.add(
+                HtmlInfoEntity(
+                    fileName,
+                    context.html2text(file).replace("GA TB Reference Guide", "")
+                )
+            )
+        }
+        return results
+    }
+
+    /** Must be called inside a DB transaction. */
+    private suspend fun rebuildGlobalSearchLocked() {
+        val globalSearch = ArrayList<GlobalSearchEntity>()
+
+        repo.db.subChapterDao().getSubChapterBindChapterSuspended().forEach { data ->
+            data.subChapterEntity.forEach { sub ->
+                globalSearch.add(
+                    GlobalSearchEntity(
+                        data.chapterEntity.chapterTitle,
+                        sub.subChapterTitle,
+                        javaClass.name,
+                        sub.url,
+                        sub.chapterId,
+                        sub.subChapterId,
+                    )
+                )
+            }
+        }
+
+        repo.db.chartDao().getChartAndSubChapterSuspend().forEach { row ->
+            globalSearch.add(
+                GlobalSearchEntity(
+                    row.chartEntity.chartTitle,
+                    row.subChapterEntity.subChapterTitle,
+                    javaClass.name,
+                    row.chartEntity.id,
+                    row.subChapterEntity.chapterId,
+                    row.subChapterEntity.subChapterId,
+                    true,
+                    row.chartEntity.id
+                )
+            )
+        }
+
+        val htmlByFileName = repo.db.htmlInfoDao()
+            .getHtmlInfoEntitySuspended()
+            .associate { it.fileName to it.htmlText }
+
+        val complete = globalSearch.mapNotNull { entry ->
+            val html = htmlByFileName[entry.fileName] ?: return@mapNotNull null
+            GlobalSearchEntity(
+                entry.searchTitle,
+                entry.subChapter,
+                html,
+                entry.fileName,
+                entry.chapterId,
+                entry.subChapterId,
+                entry.isChart,
+                entry.chartId
+            )
+        }
+
+        repo.db.globalSearchDao().insert(complete)
     }
 
 
@@ -210,7 +340,6 @@ class FAMainViewModel @Inject constructor(
             checkTriggerValue(FirebaseRemoteConfig.getInstance(), context)
 
             dumpUpdatedHTMLInfo(context)
-            bindHtmlWithChapter()
 
             // Notify success on the main thread
             withContext(Dispatchers.Main) {

--- a/app/src/main/java/org/apphatchery/gatbreferenceguide/utils/AppInitLock.kt
+++ b/app/src/main/java/org/apphatchery/gatbreferenceguide/utils/AppInitLock.kt
@@ -1,0 +1,13 @@
+package org.apphatchery.gatbreferenceguide.utils
+
+import kotlinx.coroutines.sync.Mutex
+
+/**
+ * Process-wide lock to prevent concurrent initialization work.
+ *
+ * We use this to serialize operations that can temporarily invalidate app state
+ * (e.g., replacing cached HTML content and purging+seeding the Room DB).
+ */
+object AppInitLock {
+    val mutex: Mutex = Mutex()
+}


### PR DESCRIPTION
### Summary
On a fresh install (or immediately after an app update), users could open “All Chapters / All Tables / Subchapters / Body (WebView)” successfully, but after navigating back to Home and trying again the destination screens would sometimes render blank. Force-closing and reopening the app restored normal behavior.

This PR makes initialization deterministic and removes a legacy background rebuild path that could reintroduce DB churn during navigation.

### User-visible behavior (before)
First open: Chapters/Tables/Subchapters/WebView pages load normally.
Navigate back to Home, then open again: lists/pages can appear blank.
Force close + reopen: content comes back.
### Root cause
This was a startup race between initialization tasks and UI navigation:

1. Purge/seed not strictly serialized with navigation

Initialization involved clearing cached web content and purging + reseeding Room tables.
If users navigated quickly, initialization work could overlap with UI reads (Room flows feeding adapters/WebView), leading to “empty” emissions and blank screens.

2. Multiple initialization-like paths could run concurrently

First-launch/update seeding could be triggered more than once (e.g., re-entering Home before version prefs were persisted).
A separate legacy path rebuilt the search index (bindHtmlWithChapter()) and was being triggered from the remote appendix download flow, causing additional background DB work during startup/navigation.
The net result: UI would briefly show valid data, then observe empty/partial DB state, producing blank screens until a restart put the app back into a stable, fully-seeded state.

### Solution
1) Single-shot, atomic purge + seed + search rebuild
A new initialization routine loads bundled JSON + HTML search text from assets and performs:

- deletes (purge)

- inserts (seed)

- global-search rebuild

- all inside a single Room transaction.

2) Serialize init work across the process
A process-wide coroutine Mutex prevents overlapping init runs and also protects cache web-content repair, so navigation cannot cause concurrent “clear + rebuild” operations.

3) Remove legacy background global-search rebuild trigger
The remote appendix download flow no longer calls the legacy bindHtmlWithChapter() rebuild, preventing extra DB churn during normal navigation.

### Key code (solution excerpt)
1. AppInnitLock.kt

```kotlin
// Process-wide lock to prevent concurrent initialization work.
object AppInitLock {
    val mutex: Mutex = Mutex()
}
```
2. FAMainViewModel.kt
```kotlin

// One-shot initialization for first install / app update.
// Purge + seed + global-search rebuild are done atomically in one transaction.
suspend fun purgeAndSeedFromAssets(context: Context) {
    val charts: List<ChartEntity> = parseAssetJson(context, "chart.json")
    val chapters: List<ChapterEntity> = parseAssetJson(context, "chapter.json")
    val subChapters: List<SubChapterEntity> = parseAssetJson(context, "subchapter.json")
    val htmlInfo: List<HtmlInfoEntity> = extractHtmlInfoFromAssets(context)

    repo.db.withTransaction {
        // Database.purgeData() not called here because (it starts its own transaction).
        repo.db.chapterDao().deleteAll()
        repo.db.chartDao().deleteAll()
        repo.db.subChapterDao().deleteAll()
        repo.db.htmlInfoDao().deleteAll()
        repo.db.globalSearchDao().deleteAll()

        repo.db.chapterDao().insert(chapters)
        repo.db.subChapterDao().insert(subChapters)
        repo.db.chartDao().insert(charts)
        repo.db.htmlInfoDao().insert(htmlInfo)

        rebuildGlobalSearchLocked()
    }
}
```
3. MainFragment .kt
```kotlin
// MainFragment init/firstLaunch are serialized to avoid overlapping clear/seed work.
lifecycleScope.launch(Dispatchers.IO) {
    AppInitLock.mutex.withLock {
        applicationContext.replaceBundledGuideWebContent()
        LegacyNotesMigrator.migrateNoteTargets(db)
        viewModel.purgeAndSeedFromAssets(applicationContext)

        userPrefs.setBuildVersion(BUILD_VERSION)
        userPrefs.setPendoVisitorId(getVisitorId())
    }

    withContext(Dispatchers.Main) {
        init()
    }
}
```

```kotlin
// Remote appendix download no longer triggers the legacy global-search rebuild.
// (It still updates HtmlInfo for the downloaded page.)
dumpUpdatedHTMLInfo(context)
// bindHtmlWithChapter()   <-- removed to prevent extra DB churn during navigation
```
### Testing

1. Uninstall the app (to simulate fresh install) 

2. Launch app and wait for initial load to complete.

3.  As soon as Main Fragment (home) loads, **Quickly** Tap “All Chapters” → All Chapters List → Sub chapter →Content.

4. Navigate back to Home using the back button

5. Tap “All Chapters” again → verify chapter list renders (no blank screen).
6. Repeate the whole process again several times  

7. Repeat with “All Tables”, then open a Subchapter into the Body/WebView and repeat back-to-Home/open again.

**Additional checks**

1. Background the app and resume during/after initialization; verify content still renders.

2. Confirm first 6 chapters/tables on Home populate after seed.

3. Confirm WebView pages load from cache as expected.
4. Verify also that this fix works if user updates from version 1.16 to version 2.0 and had bookmarks and notes saved on content pages that have been changed

### Files touched (high level)

1.FAMainViewModel: adds single-shot atomic seed routine; removes legacy rebuild trigger from appendix download path.
2.MainFragment: serializes first-launch/update initialization and cache content repair behind a shared mutex.
3.Database/DAOs: supports deterministic purge/seed instrumentation and count helpers (where used).
5.AppInitLock: process-wide initialization mutex holder.