### PR TITLE
Set windowBackground on layouts

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,8 @@
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="?android:attr/windowBackground">
 
     <!-- custom View for the colored status bar -->
     <View

--- a/app/src/main/res/layout/fragment_global_search.xml
+++ b/app/src/main/res/layout/fragment_global_search.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?android:attr/windowBackground"
     tools:context=".ui.fragments.GlobalSearchFragment">
 
     <androidx.appcompat.widget.LinearLayoutCompat


### PR DESCRIPTION
Apply the theme window background to root view groups to ensure consistent app background across screens. Added android:background="?android:attr/windowBackground" to app/src/main/res/layout/activity_main.xml and app/src/main/res/layout/fragment_global_search.xml to avoid visual inconsistencies with different themes.
This pull request makes minor UI improvements by ensuring that the app's main activity and global search fragment both use the system window background, resulting in a more consistent appearance across screens.

* UI consistency improvements:
  * Added `android:background="?android:attr/windowBackground"` to the root layout in `activity_main.xml` for main activity background consistency.
  * Added `android:background="?android:attr/windowBackground"` to the root layout in `fragment_global_search.xml` for search fragment background consistency.